### PR TITLE
chore: add Dependabot configuration (incomplete)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
Adds a Dependabot configuration file to enable automated dependency updates with a weekly schedule.

## Changes
- Added `.github/dependabot.yml` configuration file
- Configured weekly update schedule
- Set root directory for package manifest location

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [x] Other (Infrastructure/Tooling)

## Notes
**⚠️ Configuration is incomplete**: The `package-ecosystem` field is currently empty. Based on the repository having a `package.json` file, this should likely be set to `"npm"` for the configuration to work properly.

**Suggested fix:**
```yaml
- package-ecosystem: "npm"  # Currently empty string
```

Without specifying the package ecosystem, Dependabot will not function and no automated PRs will be created for dependency updates.

---
*Auto-generated by Claude. Feel free to edit.*