### PR TITLE
docs: add missing packages to README.md structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ laxdb is a suite of management tools designed specifically for lacrosse teams an
 
 - `packages/api`: Effect-based HTTP API with RPC support
 - `packages/core`: Shared business logic, database schemas, and core services
+- `packages/docs`: Documentation site built with Fumadocs
 - `packages/web`: Main web application built with TanStack Start, deployed on Cloudflare Workers
 - `packages/marketing`: Marketing website built with TanStack Start
 - `packages/effect-cloudflare`: Effect-TS bindings for Cloudflare primitives (KV, R2, D1, etc.)
 - `packages/scripts`: Internal utility and maintenance scripts
+- `packages/ui`: Shared UI component library built with shadcn/ui (Base UI)
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
Updates the README.md to include two packages that were missing from the project structure documentation: the docs package and ui package.

## Changes
- Add `packages/docs`: Documentation site built with Fumadocs to the package list
- Add `packages/ui`: Shared UI component library built with shadcn/ui (Base UI) to the package list

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Tests
- [ ] Other

## Notes
This ensures the README accurately reflects the current monorepo structure by documenting all packages in the workspace.

---
*Auto-generated by Claude. Feel free to edit.*