### PR TITLE
feat(pipeline): add PLL data extraction framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ dist-ssr
 .tanstack
 .output
 .vinxi
+
+# pipeline extraction output
+packages/pipeline/output

--- a/packages/pipeline/docs/PLL_DATA_MODEL.md
+++ b/packages/pipeline/docs/PLL_DATA_MODEL.md
@@ -1,0 +1,573 @@
+# PLL Data Model
+
+**Purpose**: Map all PLL API entities, their relationships, and data availability before designing the database schema.
+
+---
+
+## API Endpoints Overview
+
+| Endpoint | Type | Returns | Extracted? |
+|----------|------|---------|------------|
+| `getTeams(year)` | GraphQL | Team[] with stats, coaches | Yes |
+| `getPlayers(season)` | GraphQL | Player[] with stats, allTeams | Yes |
+| `getEvents(year)` | REST | Event[] (games) with teams, scores | Yes |
+| `getStandings(year)` | REST | Standing[] with win/loss records | Yes |
+| `getStandingsGraphQL(year)` | GraphQL | Standing[] with embedded team | Yes |
+| `getPlayerDetail(slug)` | GraphQL | careerStats, allSeasonStats, accolades | No |
+| `getTeamDetail(id, year)` | GraphQL | events, coach details, allYears | No |
+| `getEventDetail(slug)` | GraphQL | playLogs (play-by-play) | No |
+| `getAdvancedPlayers(year)` | GraphQL | Rate stats, shooting hand breakdowns | No |
+| `getStatLeaders(year, stats)` | GraphQL | Leaderboards by stat | No |
+| `getCareerStats(stat)` | GraphQL | Career leaderboards | No |
+
+---
+
+## Core Entities
+
+### 1. Team
+
+**Primary Key**: `officialId` (3-letter code, e.g., "ARC", "ATL", "CAN")
+
+**From getTeams (list):**
+```typescript
+{
+  officialId: "ARC",           // Primary key
+  locationCode: "UTA",         // City abbreviation
+  location: "Utah",            // City name
+  fullName: "Archers",         // Team name
+  urlLogo: "https://...",
+  slogan: "The Peak of Excellence",
+  league: "PLL",
+  
+  // Season record
+  teamWins: 6,
+  teamLosses: 4,
+  teamTies: 0,
+  teamWinsPost: 0,
+  teamLossesPost: 0,
+  teamTiesPost: 0,
+  
+  // Embedded
+  coaches: [{ name, coachType }],  // Only name + type
+  stats: PLLTeamStats,             // Regular season stats
+  postStats: PLLTeamStats,         // Playoff stats
+  champSeries: {                   // Championship Series
+    teamWins, teamLosses, teamTies,
+    stats: PLLTeamStats
+  }
+}
+```
+
+**From getTeamDetail (detail) - additional fields:**
+```typescript
+{
+  allYears: [2019, 2020, ...],     // Years team existed
+  coaches: [{                       // More detail
+    officialId, coachType, firstName, lastName
+  }],
+  events: [{                        // Team's games
+    id, slugname, startTime, venue, ...
+  }]
+}
+```
+
+**Key insights:**
+- Teams are stable across years (same officialId)
+- Location/locationCode can change (e.g., team relocation)
+- Stats are per-year, per-segment (regular/post/champSeries)
+
+---
+
+### 2. Player
+
+**Primary Key**: `officialId` (6-digit string, e.g., "000365")
+
+**From getPlayers (list):**
+```typescript
+{
+  officialId: "000365",        // Primary key
+  firstName: "Jack",
+  lastName: "Rowlett",
+  lastNameSuffix: "",          // Jr., III, etc.
+  slug: "jack-rowlett",        // URL slug
+  
+  // Profile
+  jerseyNum: 99,               // Current jersey
+  profileUrl: "https://...",
+  handedness: "R",
+  country: "United States",
+  countryCode: "USA",
+  collegeYear: 2019,           // College graduation year
+  experience: 8,               // Years in league
+  expFromYear: 2019,           // First year
+  isCaptain: false,
+  
+  // Injury
+  injuryStatus: "H",           // H = healthy
+  injuryDescription: "",
+  
+  // Historical data
+  allYears: [2019, 2020, ...], // Years played
+  allTeams: [                  // ROSTER HISTORY
+    {
+      officialId: "CHA",       // Team ID
+      year: 2024,
+      position: "D",
+      positionName: "Defense",
+      jerseyNum: 99,
+      location: "Carolina",
+      fullName: "Chaos",
+      ...
+    },
+    // ... one entry per team per year
+  ],
+  
+  // Current year stats
+  stats: PLLPlayerStats,       // Regular season
+  postStats: PLLPlayerStats,   // Playoffs
+  champSeries: {               // Championship Series
+    position, positionName,
+    team: { officialId, ... },
+    stats: PLLPlayerStats
+  }
+}
+```
+
+**From getPlayerDetail (detail) - additional fields:**
+```typescript
+{
+  careerStats: PLLPlayerCareerStats,  // Lifetime totals
+  allSeasonStats: [                   // Per-year breakdown
+    { year, seasonSegment, teamId, gamesPlayed, goals, ... }
+  ],
+  accolades: [                        // Awards
+    { awardName: "All-Star", years: [2022, 2023] }
+  ],
+  advancedSeasonStats: {              // Advanced metrics
+    unassistedGoals, settledGoals, fastbreakGoals, ...
+  }
+}
+```
+
+**Key insights:**
+- `allTeams[]` is THE roster data - contains player-team-year-position relationships
+- Players can be on multiple teams across years (trades)
+- Stats are per-year, per-segment (regular/post/champSeries)
+- Position can change year-to-year (in allTeams)
+
+---
+
+### 3. Event (Game)
+
+**Primary Keys**: 
+- `id` (numeric, internal)
+- `slugname` (URL slug, e.g., "championship-series-1-2024-2-14")
+- `eventId` (string, e.g., "2024_cs_ev1")
+
+**From getEvents (list):**
+```typescript
+{
+  id: 234,                              // Numeric ID
+  slugname: "championship-series-...",  // URL slug
+  eventId: "2024_cs_ev1",               // Event identifier
+  externalId: "283798658",              // External system ID
+  
+  // Time & Location
+  year: 2024,
+  startTime: "1707949800",              // Unix timestamp (string!)
+  week: "0",                            // Week number
+  gameNumber: 1,
+  venue: "The St. James",
+  location: "Springfield, VA",
+  venueLocation: null,
+  
+  // Classification
+  league: "PLL",
+  seasonSegment: "champseries",         // regular, post, champseries
+  description: "Round Robin - Gm 1",
+  
+  // Status
+  eventStatus: 3,                       // Game status code
+  period: 5,                            // Current/final period
+  gameStatus: null,
+  
+  // Teams & Scores
+  homeTeam: PLLEventTeam,               // Full team object
+  awayTeam: PLLEventTeam,
+  homeScore: 25,
+  visitorScore: 26,
+  
+  // Media
+  broadcaster: ["ESPN2", "ESPN+"],
+  urlStreaming: "https://...",
+  urlTicket: "...",
+  
+  // Other
+  waitlist: false,
+  snl: false                            // Saturday Night Lacrosse
+}
+```
+
+**From getEventDetail (detail) - additional fields:**
+```typescript
+{
+  playLogs: [                           // Play-by-play
+    {
+      id: 1,
+      period: 1,
+      minutes: 12,
+      seconds: 0,
+      teamId: "ATL",
+      gbPlayerName: "Jeff Teat",
+      description: "Goal scored..."
+    },
+    // ... many entries per game
+  ]
+}
+```
+
+**Key insights:**
+- Events contain FULL team objects (duplicated data)
+- `startTime` is Unix timestamp as string
+- `seasonSegment` distinguishes game type: "regular", "post", "champseries"
+- Play-by-play only available via detail endpoint
+
+---
+
+### 4. Standing
+
+**From getStandings (REST):**
+```typescript
+{
+  teamId: "ATL",              // Team reference
+  fullName: "Atlas",
+  location: "New York",
+  locationCode: "NYA",
+  urlLogo: "https://...",
+  
+  // Record
+  seed: null,                 // Playoff seed
+  wins: 7,
+  losses: 3,
+  ties: 0,
+  scores: 151,                // Points scored
+  scoresAgainst: 124,
+  scoreDiff: 27,
+  
+  // Conference
+  conference: "eastern",
+  conferenceSeed: null,
+  conferenceWins: 0,
+  conferenceLosses: 0,
+  conferenceTies: 0,
+  conferenceScores: 0,
+  conferenceScoresAgainst: 0
+}
+```
+
+**From getStandingsGraphQL - same data but with nested team object**
+
+**Key insights:**
+- Standings are per-year snapshots
+- Can request regular OR champSeries standings
+- Essentially duplicate of team record data
+
+---
+
+### 5. Coach
+
+**From getTeams (embedded in Team):**
+```typescript
+{
+  name: "Chris Bates",
+  coachType: "head"           // head, assistant
+}
+```
+
+**From getTeamDetail (more detail):**
+```typescript
+{
+  officialId: "...",          // Coach ID
+  coachType: "head",
+  firstName: "Chris",
+  lastName: "Bates"
+}
+```
+
+**Key insights:**
+- Coaches only available embedded in Team
+- List endpoint has less detail than detail endpoint
+- Would need team detail to get coach IDs
+
+---
+
+## Entity Relationships
+
+```
+┌─────────────┐
+│   League    │  (PLL - hardcoded for now)
+└──────┬──────┘
+       │
+       │ 1:N
+       ▼
+┌─────────────┐      ┌─────────────┐
+│   Season    │──────│  Standing   │  (year snapshot)
+│   (year)    │ 1:N  └──────┬──────┘
+└──────┬──────┘             │ N:1
+       │                    ▼
+       │ 1:N         ┌─────────────┐
+       ├────────────▶│    Team     │◀──────────────┐
+       │             └──────┬──────┘               │
+       │                    │ 1:N                  │
+       │                    ▼                      │
+       │             ┌─────────────┐               │
+       │             │   Coach     │               │
+       │             └─────────────┘               │
+       │                                           │
+       │ 1:N                                       │
+       ├─────────────────────────────────────┐     │
+       ▼                                     │     │
+┌─────────────┐                              │     │
+│   Player    │                              │     │
+└──────┬──────┘                              │     │
+       │                                     │     │
+       │ 1:N (via allTeams)                  │     │
+       ▼                                     │     │
+┌─────────────────────┐                      │     │
+│   Roster Entry      │──────────────────────┘     │
+│ (player+team+year)  │                            │
+│   position, jersey  │                            │
+└─────────────────────┘                            │
+                                                   │
+       ┌───────────────────────────────────────────┘
+       │ (home/away)
+       ▼
+┌─────────────┐
+│   Event     │  (Game)
+│   (Game)    │
+└──────┬──────┘
+       │ 1:N
+       ▼
+┌─────────────┐
+│  Play Log   │  (play-by-play, detail only)
+└─────────────┘
+```
+
+---
+
+## Stats Breakdown
+
+Stats exist at multiple levels:
+
+### Player Stats (PLLPlayerStats) - per player per season segment
+- Goals, assists, points
+- Shots, shot %, shots on goal
+- Two-point shots/goals
+- Ground balls, turnovers, caused turnovers
+- Faceoffs (won, lost, %)
+- Saves, save %, goals against, GAA
+- Penalties (count, PIM)
+- Power play / short handed stats
+- Advanced: touches, passes, rates
+
+### Team Stats (PLLTeamStats) - per team per season segment
+- Scores, scores against, goals
+- Shots, shot %, shots on goal
+- Two-point stats
+- Ground balls, turnovers, caused turnovers
+- Faceoffs (won, lost, %)
+- Clears, clear %
+- Rides, ride %
+- Saves, save %, goals against
+- Penalties, PIM
+- Power play / man down stats
+
+### Career Stats (PLLPlayerCareerStats) - lifetime
+- Aggregated totals across all seasons
+
+### Season Stats (PLLPlayerSeasonStats) - per year per segment
+- Available in player detail only
+- Shows year + seasonSegment + teamId + stats
+
+---
+
+## Data Gaps & Decisions Needed
+
+### 1. Play-by-play (Event Details)
+- **Cost**: ~300 API calls (50-60 events × 7 years)
+- **Value**: Enables game flow analysis, play-level stats
+- **Decision**: Defer until core data is stable
+
+### 2. Player Career Stats & Accolades
+- **Cost**: ~1400 API calls (200 players × 7 years, but one call per player)
+- **Value**: Enables career leaderboards, awards display
+- **Decision**: Extract after core sync is working
+
+### 3. Coach Details
+- **Cost**: ~56 API calls (8 teams × 7 years)
+- **Value**: Coach IDs, proper name parsing
+- **Decision**: Can extract via team details
+
+### 4. Advanced Stats
+- **Cost**: ~7 API calls (one per year)
+- **Value**: Rate-based stats, shooting hand analysis
+- **Decision**: Extract alongside players
+
+---
+
+## Extraction Strategy
+
+### Phase 1: Core Data (DONE)
+- [x] Teams per year (list)
+- [x] Players per year (list)
+- [x] Events per year (list)
+- [x] Standings per year
+
+### Phase 2: Enhanced Data (DONE)
+- [x] Advanced players per year (rate stats) - extracted for all years
+- [x] Player details sample - analyzed data structure
+- [ ] Team details per year (coach IDs, proper events) - optional
+
+### Phase 3: Detail Data (DECIDE)
+- [ ] Player details (full extraction) - ~200 players, gets accolades + career stats
+- [ ] Event details (play-by-play) - ~330 events
+- [ ] Stat leaders per year - 7 calls
+
+---
+
+## Sample Analysis Results
+
+### Player Detail Endpoint - Value Assessment
+
+Sampled 5 top players (Jeff Teat, Tre Leclaire, Zed Williams, Connor Fields, Marcus Holman).
+
+| Field | Unique to Detail? | Value |
+|-------|-------------------|-------|
+| `careerStats` | YES | Lifetime totals (25 fields) |
+| `allSeasonStats` | YES (historical) | Stats per year/segment (current year in list) |
+| `accolades` | YES | Awards (All-Star, MVP, ROY, etc.) |
+| `advancedSeasonStats` | NO (same as getAdvancedPlayers) | Rate stats, shooting breakdowns |
+
+### Accolade Examples (Jeff Teat)
+```json
+[
+  { "awardName": "All-Star", "years": [2021, 2022, 2023, 2024, 2025] },
+  { "awardName": "ROY", "years": [2021] },
+  { "awardName": "1st Team All-Pro", "years": [2021, 2024] },
+  { "awardName": "2nd Team All-Pro", "years": [2022, 2023, 2025] },
+  { "awardName": "MVP", "years": [2024] },
+  { "awardName": "AOY", "years": [2024] }
+]
+```
+
+### Decision: Full Player Detail Extraction
+
+**Recommendation**: Extract player details for ALL unique players (not per-year).
+
+Why:
+- Accolades are UNIQUE and valuable (awards, honors)
+- `careerStats` gives lifetime totals without recalculation
+- `allSeasonStats` provides historical data in one call
+- One call per player (not per year) - ~200-250 unique players total
+
+Cost: ~250 API calls (one-time)
+Value: High (enables awards display, career leaderboards)
+
+---
+
+## ID Reference
+
+| Entity | Primary ID | Other IDs |
+|--------|-----------|-----------|
+| Team | `officialId` (e.g., "ARC") | `team_id` in some contexts |
+| Player | `officialId` (e.g., "000365") | `slug` for URLs |
+| Event | `id` (numeric) | `slugname`, `eventId`, `externalId` |
+| Coach | `officialId` | Only in team detail |
+| Standing | None (team + year combo) | Uses `teamId` reference |
+
+---
+
+## Team Reference
+
+### All-Time Teams
+
+| officialId | location | fullName | Years Active | Notes |
+|------------|----------|----------|--------------|-------|
+| ARC | Utah | Archers | 2019-present | |
+| ATL | New York | Atlas | 2019-present | |
+| CAN | Boston | Cannons | 2021-present | MLL merger |
+| CHA | Carolina | Chaos | 2019-present | |
+| CHR | - | Chrome | 2019-2023 | Became Outlaws |
+| OUT | Denver | Outlaws | 2024-present | Rebranded from Chrome |
+| RED | California | Redwoods | 2019-present | |
+| WAT | Philadelphia | Waterdogs | 2020-present | |
+| WHP | Maryland | Whipsnakes | 2019-present | |
+
+### Team Count by Year
+
+| Year | Teams | Changes |
+|------|-------|---------|
+| 2019 | 6 | ARC, ATL, CHA, CHR, RED, WHP (founding) |
+| 2020 | 7 | + WAT (Waterdogs added) |
+| 2021 | 8 | + CAN (Cannons, from MLL merger) |
+| 2022 | 8 | |
+| 2023 | 8 | |
+| 2024 | 8 | CHR → OUT (Chrome rebranded to Outlaws) |
+| 2025 | 8 | |
+
+### Notes
+- Location data (`location`, `locationCode`) only populated from 2024 onwards in list endpoints
+- CHR and OUT are the same franchise - Chrome rebranded to Outlaws for 2024 season
+- Players who were on Chrome in 2023 may show as being on a different team in 2024 (Outlaws or traded)
+
+---
+
+## Enumerated Values
+
+### Positions
+| Code | Name | Description |
+|------|------|-------------|
+| A | Attack | Offensive player |
+| M | Midfield | Two-way player |
+| D | Defense | Defensive player |
+| G | Goalie | Goalkeeper |
+| FO | Faceoff | Faceoff specialist |
+| LSM | Long Stick Middie | Defensive midfielder with long stick |
+| SSDM | Short Stick Defensive Middie | Defensive midfielder with short stick |
+
+### Season Segments
+| Value | Description |
+|-------|-------------|
+| `regular` | Regular season games |
+| `post` | Playoff games |
+| `champseries` | Championship Series (round-robin tournament) |
+| `allstar` | All-Star game |
+
+### Handedness
+| Value | Description |
+|-------|-------------|
+| `R` | Right-handed |
+| `L` | Left-handed |
+| `R/L` | Primarily right, can play left |
+| `L/R` | Primarily left, can play right |
+
+### Event Status
+| Value | Meaning (inferred) |
+|-------|---------------------|
+| 1 | Scheduled |
+| 2 | In Progress |
+| 3 | Final/Completed |
+
+### Coach Types
+| Value | Description |
+|-------|-------------|
+| `head` | Head coach |
+| `assistant` | Assistant coach |
+
+### Injury Status
+| Value | Meaning (inferred) |
+|-------|---------------------|
+| `H` | Healthy |
+| `Q` | Questionable |
+| `O` | Out |
+| `IR` | Injured Reserve |

--- a/packages/pipeline/src/api-client/graphql.service.ts
+++ b/packages/pipeline/src/api-client/graphql.service.ts
@@ -4,7 +4,6 @@ import {
   NetworkError,
   ParseError,
   type PipelineError,
-  RateLimitError,
   TimeoutError,
 } from "../error";
 import { DEFAULT_PIPELINE_CONFIG } from "../config";

--- a/packages/pipeline/src/api-client/rest-client.service.ts
+++ b/packages/pipeline/src/api-client/rest-client.service.ts
@@ -1,4 +1,4 @@
-import { Context, Duration, Effect, Layer, Schedule, Schema } from "effect";
+import { Duration, Effect, Schedule, Schema } from "effect";
 import {
   HttpError,
   NetworkError,

--- a/packages/pipeline/src/extract/extract.config.ts
+++ b/packages/pipeline/src/extract/extract.config.ts
@@ -1,0 +1,38 @@
+import { Effect, Config } from "effect";
+import * as path from "node:path";
+
+export interface ExtractConfig {
+  readonly outputDir: string;
+  readonly concurrency: number;
+  readonly delayBetweenRequestsMs: number;
+  readonly delayBetweenBatchesMs: number;
+}
+
+const DEFAULT_OUTPUT_DIR = path.join(process.cwd(), "output");
+
+export class ExtractConfigService extends Effect.Service<ExtractConfigService>()(
+  "ExtractConfigService",
+  {
+    effect: Effect.gen(function* () {
+      const outputDir = yield* Config.string("EXTRACT_OUTPUT_DIR").pipe(
+        Config.withDefault(DEFAULT_OUTPUT_DIR),
+      );
+      const concurrency = yield* Config.number("EXTRACT_CONCURRENCY").pipe(
+        Config.withDefault(5),
+      );
+      const delayBetweenRequestsMs = yield* Config.number(
+        "EXTRACT_DELAY_MS",
+      ).pipe(Config.withDefault(100));
+      const delayBetweenBatchesMs = yield* Config.number(
+        "EXTRACT_BATCH_DELAY_MS",
+      ).pipe(Config.withDefault(500));
+
+      return {
+        outputDir,
+        concurrency,
+        delayBetweenRequestsMs,
+        delayBetweenBatchesMs,
+      } satisfies ExtractConfig;
+    }),
+  },
+) {}

--- a/packages/pipeline/src/extract/extract.schema.ts
+++ b/packages/pipeline/src/extract/extract.schema.ts
@@ -1,0 +1,55 @@
+import { Schema } from "effect";
+
+export const EntityStatus = Schema.Struct({
+  extracted: Schema.Boolean,
+  count: Schema.Number,
+  timestamp: Schema.String,
+  durationMs: Schema.optional(Schema.Number),
+});
+export type EntityStatus = typeof EntityStatus.Type;
+
+export const SeasonManifest = Schema.Struct({
+  teams: EntityStatus,
+  teamDetails: EntityStatus,
+  players: EntityStatus,
+  playerDetails: EntityStatus,
+  advancedPlayers: EntityStatus,
+  events: EntityStatus,
+  eventDetails: EntityStatus,
+  standings: EntityStatus,
+  standingsCS: EntityStatus,
+});
+export type SeasonManifest = typeof SeasonManifest.Type;
+
+export const ExtractionManifest = Schema.Struct({
+  source: Schema.String,
+  seasons: Schema.Record({ key: Schema.String, value: SeasonManifest }),
+  lastRun: Schema.String,
+  version: Schema.Number,
+});
+export type ExtractionManifest = typeof ExtractionManifest.Type;
+
+export const createEmptyEntityStatus = (): EntityStatus => ({
+  extracted: false,
+  count: 0,
+  timestamp: "",
+});
+
+export const createEmptySeasonManifest = (): SeasonManifest => ({
+  teams: createEmptyEntityStatus(),
+  teamDetails: createEmptyEntityStatus(),
+  players: createEmptyEntityStatus(),
+  playerDetails: createEmptyEntityStatus(),
+  advancedPlayers: createEmptyEntityStatus(),
+  events: createEmptyEntityStatus(),
+  eventDetails: createEmptyEntityStatus(),
+  standings: createEmptyEntityStatus(),
+  standingsCS: createEmptyEntityStatus(),
+});
+
+export const createEmptyManifest = (source: string): ExtractionManifest => ({
+  source,
+  seasons: {},
+  lastRun: "",
+  version: 1,
+});

--- a/packages/pipeline/src/extract/index.ts
+++ b/packages/pipeline/src/extract/index.ts
@@ -1,0 +1,11 @@
+export { ExtractConfigService } from "./extract.config";
+export type { ExtractConfig } from "./extract.config";
+export {
+  type ExtractionManifest,
+  type SeasonManifest,
+  type EntityStatus,
+  createEmptyManifest,
+  createEmptySeasonManifest,
+  createEmptyEntityStatus,
+} from "./extract.schema";
+export { PLLExtractorService, PLLManifestService } from "./pll";

--- a/packages/pipeline/src/extract/pll/index.ts
+++ b/packages/pipeline/src/extract/pll/index.ts
@@ -1,0 +1,2 @@
+export { PLLManifestService } from "./pll.manifest";
+export { PLLExtractorService } from "./pll.extractor";

--- a/packages/pipeline/src/extract/pll/pll.extractor.ts
+++ b/packages/pipeline/src/extract/pll/pll.extractor.ts
@@ -1,0 +1,585 @@
+import { Effect, Duration } from "effect";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { PLLClient } from "../../pll/pll.client";
+import type {
+  PLLTeam,
+  PLLPlayer,
+  PLLEvent,
+  PLLTeamDetail,
+  PLLPlayerDetail,
+  PLLEventDetail,
+  PLLTeamStanding,
+  PLLGraphQLStanding,
+  PLLAdvancedPlayer,
+} from "../../pll/pll.schema";
+import { ExtractConfigService } from "../extract.config";
+import { PLLManifestService } from "./pll.manifest";
+import type { ExtractionManifest, SeasonManifest } from "../extract.schema";
+
+const PLL_YEARS = [2019, 2020, 2021, 2022, 2023, 2024, 2025] as const;
+type PLLYear = (typeof PLL_YEARS)[number];
+
+interface ExtractResult<T> {
+  data: T;
+  count: number;
+  durationMs: number;
+}
+
+const saveJson = <T>(filePath: string, data: T) =>
+  Effect.gen(function* () {
+    const dir = path.dirname(filePath);
+    yield* Effect.tryPromise({
+      try: () => fs.mkdir(dir, { recursive: true }),
+      catch: (e) => new Error(`Failed to create directory: ${String(e)}`),
+    });
+    yield* Effect.tryPromise({
+      try: () => fs.writeFile(filePath, JSON.stringify(data, null, 2)),
+      catch: (e) => new Error(`Failed to write file: ${String(e)}`),
+    });
+  });
+
+const withTiming = <T, E, R>(
+  effect: Effect.Effect<T, E, R>,
+): Effect.Effect<ExtractResult<T>, E, R> =>
+  Effect.gen(function* () {
+    const start = Date.now();
+    const data = yield* effect;
+    const durationMs = Date.now() - start;
+    const count = Array.isArray(data) ? data.length : 1;
+    return { data, count, durationMs };
+  });
+
+export class PLLExtractorService extends Effect.Service<PLLExtractorService>()(
+  "PLLExtractorService",
+  {
+    effect: Effect.gen(function* () {
+      const pll = yield* PLLClient;
+      const config = yield* ExtractConfigService;
+      const manifestService = yield* PLLManifestService;
+      yield* Effect.log(`Output directory: ${config.outputDir}`);
+
+      const getOutputPath = (year: number, entity: string) =>
+        path.join(config.outputDir, "pll", String(year), `${entity}.json`);
+
+      const extractTeams = (year: number) =>
+        Effect.gen(function* () {
+          yield* Effect.log(`  📊 Extracting teams for ${year}...`);
+          const result = yield* withTiming(
+            pll.getTeams({ year, includeChampSeries: true }),
+          );
+          yield* saveJson(getOutputPath(year, "teams"), result.data);
+          yield* Effect.log(
+            `     ✓ ${result.count} teams (${result.durationMs}ms)`,
+          );
+          return result;
+        }).pipe(
+          Effect.catchAll((e) => {
+            return Effect.gen(function* () {
+              yield* Effect.log(`     ✗ Failed: ${e}`);
+              return {
+                data: [] as readonly PLLTeam[],
+                count: 0,
+                durationMs: 0,
+              };
+            });
+          }),
+        );
+
+      const extractTeamDetails = (year: number, teams: readonly PLLTeam[]) =>
+        Effect.gen(function* () {
+          yield* Effect.log(`  🏟️ Extracting team details for ${year}...`);
+          const start = Date.now();
+
+          const details: PLLTeamDetail[] = [];
+          for (const team of teams) {
+            const detail = yield* pll
+              .getTeamDetail({
+                id: team.officialId,
+                year,
+                statsYear: year,
+                eventsYear: year,
+                includeChampSeries: true,
+              })
+              .pipe(
+                Effect.catchAll(() => Effect.succeed(null)),
+                Effect.tap(() =>
+                  Effect.sleep(Duration.millis(config.delayBetweenRequestsMs)),
+                ),
+              );
+            if (detail) {
+              details.push(detail);
+            }
+          }
+
+          const durationMs = Date.now() - start;
+          yield* saveJson(getOutputPath(year, "team-details"), details);
+          yield* Effect.log(
+            `     ✓ ${details.length} team details (${durationMs}ms)`,
+          );
+
+          return { data: details, count: details.length, durationMs };
+        }).pipe(
+          Effect.catchAll((e) => {
+            return Effect.gen(function* () {
+              yield* Effect.log(`     ✗ Failed: ${e}`);
+              return { data: [] as PLLTeamDetail[], count: 0, durationMs: 0 };
+            });
+          }),
+        );
+
+      const extractPlayers = (year: number) =>
+        Effect.gen(function* () {
+          yield* Effect.log(`  👥 Extracting players for ${year}...`);
+          const result = yield* withTiming(
+            pll.getPlayers({
+              season: year,
+              includeReg: true,
+              includePost: true,
+              includeZPP: true,
+              limit: 1000,
+            }),
+          );
+          yield* saveJson(getOutputPath(year, "players"), result.data);
+          yield* Effect.log(
+            `     ✓ ${result.count} players (${result.durationMs}ms)`,
+          );
+          return result;
+        }).pipe(
+          Effect.catchAll((e) => {
+            return Effect.gen(function* () {
+              yield* Effect.log(`     ✗ Failed: ${e}`);
+              return {
+                data: [] as readonly PLLPlayer[],
+                count: 0,
+                durationMs: 0,
+              };
+            });
+          }),
+        );
+
+      const extractAdvancedPlayers = (year: number) =>
+        Effect.gen(function* () {
+          yield* Effect.log(`  🔬 Extracting advanced players for ${year}...`);
+          const result = yield* withTiming(
+            pll.getAdvancedPlayers({
+              year,
+              limit: 500,
+              league: "PLL",
+            }),
+          );
+          yield* saveJson(getOutputPath(year, "advanced-players"), result.data);
+          yield* Effect.log(
+            `     ✓ ${result.count} advanced players (${result.durationMs}ms)`,
+          );
+          return result;
+        }).pipe(
+          Effect.catchAll((e) => {
+            return Effect.gen(function* () {
+              yield* Effect.log(`     ✗ Failed: ${e}`);
+              return {
+                data: [] as readonly PLLAdvancedPlayer[],
+                count: 0,
+                durationMs: 0,
+              };
+            });
+          }),
+        );
+
+      const extractPlayerDetails = (
+        year: number,
+        players: readonly PLLPlayer[],
+      ) =>
+        Effect.gen(function* () {
+          yield* Effect.log(`  👤 Extracting player details for ${year}...`);
+          const start = Date.now();
+
+          const playersWithSlug = players.filter((p) => p.slug !== null);
+          yield* Effect.log(
+            `     Processing ${playersWithSlug.length} players with slugs...`,
+          );
+
+          const details: PLLPlayerDetail[] = [];
+          let processed = 0;
+
+          for (const player of playersWithSlug) {
+            if (!player.slug) continue;
+
+            const detail = yield* pll
+              .getPlayerDetail({
+                slug: player.slug,
+                year,
+                statsYear: year,
+              })
+              .pipe(
+                Effect.catchAll(() => Effect.succeed(null)),
+                Effect.tap(() =>
+                  Effect.sleep(Duration.millis(config.delayBetweenRequestsMs)),
+                ),
+              );
+            if (detail) {
+              details.push(detail);
+            }
+            processed++;
+            if (processed % 50 === 0) {
+              yield* Effect.log(
+                `     ... ${processed}/${playersWithSlug.length} processed`,
+              );
+            }
+          }
+
+          const durationMs = Date.now() - start;
+          yield* saveJson(getOutputPath(year, "player-details"), details);
+          yield* Effect.log(
+            `     ✓ ${details.length} player details (${durationMs}ms)`,
+          );
+
+          return { data: details, count: details.length, durationMs };
+        }).pipe(
+          Effect.catchAll((e) => {
+            return Effect.gen(function* () {
+              yield* Effect.log(`     ✗ Failed: ${e}`);
+              return { data: [] as PLLPlayerDetail[], count: 0, durationMs: 0 };
+            });
+          }),
+        );
+
+      const extractEvents = (year: number) =>
+        Effect.gen(function* () {
+          yield* Effect.log(`  🎮 Extracting events for ${year}...`);
+          const result = yield* withTiming(pll.getEvents({ year }));
+          yield* saveJson(getOutputPath(year, "events"), result.data);
+          yield* Effect.log(
+            `     ✓ ${result.count} events (${result.durationMs}ms)`,
+          );
+          return result;
+        }).pipe(
+          Effect.catchAll((e) => {
+            return Effect.gen(function* () {
+              yield* Effect.log(`     ✗ Failed: ${e}`);
+              return {
+                data: [] as readonly PLLEvent[],
+                count: 0,
+                durationMs: 0,
+              };
+            });
+          }),
+        );
+
+      const extractEventDetails = (year: number, events: readonly PLLEvent[]) =>
+        Effect.gen(function* () {
+          yield* Effect.log(`  📋 Extracting event details for ${year}...`);
+          const start = Date.now();
+
+          const completedEvents = events.filter(
+            (e) => e.eventStatus === 3 && e.slugname,
+          );
+          yield* Effect.log(
+            `     Processing ${completedEvents.length} completed events...`,
+          );
+
+          const details: PLLEventDetail[] = [];
+          for (const event of completedEvents) {
+            if (!event.slugname) continue;
+
+            const detail = yield* pll
+              .getEventDetail({ slug: event.slugname })
+              .pipe(
+                Effect.catchAll(() => Effect.succeed(null)),
+                Effect.tap(() =>
+                  Effect.sleep(Duration.millis(config.delayBetweenRequestsMs)),
+                ),
+              );
+            if (detail) {
+              details.push(detail);
+            }
+          }
+
+          const durationMs = Date.now() - start;
+          yield* saveJson(getOutputPath(year, "event-details"), details);
+          yield* Effect.log(
+            `     ✓ ${details.length} event details (${durationMs}ms)`,
+          );
+
+          return { data: details, count: details.length, durationMs };
+        }).pipe(
+          Effect.catchAll((e) => {
+            return Effect.gen(function* () {
+              yield* Effect.log(`     ✗ Failed: ${e}`);
+              return { data: [] as PLLEventDetail[], count: 0, durationMs: 0 };
+            });
+          }),
+        );
+
+      const extractStandings = (year: number) =>
+        Effect.gen(function* () {
+          yield* Effect.log(`  📈 Extracting standings for ${year}...`);
+          const result = yield* withTiming(
+            pll.getStandings({ year, champSeries: false }),
+          );
+          yield* saveJson(getOutputPath(year, "standings"), result.data);
+          yield* Effect.log(
+            `     ✓ ${result.count} standings (${result.durationMs}ms)`,
+          );
+          return result;
+        }).pipe(
+          Effect.catchAll((e) => {
+            return Effect.gen(function* () {
+              yield* Effect.log(`     ✗ Failed: ${e}`);
+              return {
+                data: [] as readonly PLLTeamStanding[],
+                count: 0,
+                durationMs: 0,
+              };
+            });
+          }),
+        );
+
+      const extractStandingsCS = (year: number) =>
+        Effect.gen(function* () {
+          yield* Effect.log(
+            `  🏆 Extracting champ series standings for ${year}...`,
+          );
+          const result = yield* withTiming(
+            pll.getStandingsGraphQL({ year, champSeries: true }),
+          );
+          yield* saveJson(getOutputPath(year, "standings-cs"), result.data);
+          yield* Effect.log(
+            `     ✓ ${result.count} CS standings (${result.durationMs}ms)`,
+          );
+          return result;
+        }).pipe(
+          Effect.catchAll((e) => {
+            return Effect.gen(function* () {
+              yield* Effect.log(`     ✗ Failed: ${e}`);
+              return {
+                data: [] as readonly PLLGraphQLStanding[],
+                count: 0,
+                durationMs: 0,
+              };
+            });
+          }),
+        );
+
+      const extractYear = (
+        year: number,
+        options: {
+          includeDetails?: boolean;
+          skipExisting?: boolean;
+        } = {},
+      ) =>
+        Effect.gen(function* () {
+          const { includeDetails = true, skipExisting = true } = options;
+
+          yield* Effect.log(`\n${"=".repeat(50)}`);
+          yield* Effect.log(`Extracting PLL ${year}`);
+          yield* Effect.log("=".repeat(50));
+
+          let manifest = yield* manifestService.load;
+
+          const shouldExtract = (entity: keyof SeasonManifest): boolean => {
+            if (!skipExisting) return true;
+            return !manifestService.isExtracted(manifest, year, entity);
+          };
+
+          if (shouldExtract("teams")) {
+            const result = yield* extractTeams(year);
+            manifest = manifestService.markComplete(
+              manifest,
+              year,
+              "teams",
+              result.count,
+              result.durationMs,
+            );
+            yield* manifestService.save(manifest);
+          } else {
+            yield* Effect.log("  📊 Teams: skipped (already extracted)");
+          }
+
+          if (includeDetails && shouldExtract("teamDetails")) {
+            const teamsPath = getOutputPath(year, "teams");
+            const teamsData = yield* Effect.tryPromise({
+              try: () => fs.readFile(teamsPath, "utf-8"),
+              catch: () => "[]",
+            });
+            const teams = JSON.parse(teamsData) as PLLTeam[];
+            if (teams.length > 0) {
+              const result = yield* extractTeamDetails(year, teams);
+              manifest = manifestService.markComplete(
+                manifest,
+                year,
+                "teamDetails",
+                result.count,
+                result.durationMs,
+              );
+              yield* manifestService.save(manifest);
+            }
+          } else if (includeDetails) {
+            yield* Effect.log("  🏟️ Team details: skipped (already extracted)");
+          }
+
+          if (shouldExtract("players")) {
+            const result = yield* extractPlayers(year);
+            manifest = manifestService.markComplete(
+              manifest,
+              year,
+              "players",
+              result.count,
+              result.durationMs,
+            );
+            yield* manifestService.save(manifest);
+          } else {
+            yield* Effect.log("  👥 Players: skipped (already extracted)");
+          }
+
+          if (shouldExtract("advancedPlayers")) {
+            const result = yield* extractAdvancedPlayers(year);
+            manifest = manifestService.markComplete(
+              manifest,
+              year,
+              "advancedPlayers",
+              result.count,
+              result.durationMs,
+            );
+            yield* manifestService.save(manifest);
+          } else {
+            yield* Effect.log(
+              "  🔬 Advanced players: skipped (already extracted)",
+            );
+          }
+
+          if (includeDetails && shouldExtract("playerDetails")) {
+            const playersPath = getOutputPath(year, "players");
+            const playersData = yield* Effect.tryPromise({
+              try: () => fs.readFile(playersPath, "utf-8"),
+              catch: () => "[]",
+            });
+            const players = JSON.parse(playersData) as PLLPlayer[];
+            if (players.length > 0) {
+              const result = yield* extractPlayerDetails(year, players);
+              manifest = manifestService.markComplete(
+                manifest,
+                year,
+                "playerDetails",
+                result.count,
+                result.durationMs,
+              );
+              yield* manifestService.save(manifest);
+            }
+          } else if (includeDetails) {
+            yield* Effect.log(
+              "  👤 Player details: skipped (already extracted)",
+            );
+          }
+
+          if (shouldExtract("events")) {
+            const result = yield* extractEvents(year);
+            manifest = manifestService.markComplete(
+              manifest,
+              year,
+              "events",
+              result.count,
+              result.durationMs,
+            );
+            yield* manifestService.save(manifest);
+          } else {
+            yield* Effect.log("  🎮 Events: skipped (already extracted)");
+          }
+
+          if (includeDetails && shouldExtract("eventDetails")) {
+            const eventsPath = getOutputPath(year, "events");
+            const eventsData = yield* Effect.tryPromise({
+              try: () => fs.readFile(eventsPath, "utf-8"),
+              catch: () => "[]",
+            });
+            const events = JSON.parse(eventsData) as PLLEvent[];
+            if (events.length > 0) {
+              const result = yield* extractEventDetails(year, events);
+              manifest = manifestService.markComplete(
+                manifest,
+                year,
+                "eventDetails",
+                result.count,
+                result.durationMs,
+              );
+              yield* manifestService.save(manifest);
+            }
+          } else if (includeDetails) {
+            yield* Effect.log(
+              "  📋 Event details: skipped (already extracted)",
+            );
+          }
+
+          if (shouldExtract("standings")) {
+            const result = yield* extractStandings(year);
+            manifest = manifestService.markComplete(
+              manifest,
+              year,
+              "standings",
+              result.count,
+              result.durationMs,
+            );
+            yield* manifestService.save(manifest);
+          } else {
+            yield* Effect.log("  📈 Standings: skipped (already extracted)");
+          }
+
+          if (shouldExtract("standingsCS")) {
+            const result = yield* extractStandingsCS(year);
+            manifest = manifestService.markComplete(
+              manifest,
+              year,
+              "standingsCS",
+              result.count,
+              result.durationMs,
+            );
+            yield* manifestService.save(manifest);
+          } else {
+            yield* Effect.log("  🏆 CS Standings: skipped (already extracted)");
+          }
+
+          return manifest;
+        });
+
+      const extractAll = (
+        options: { includeDetails?: boolean; skipExisting?: boolean } = {},
+      ) =>
+        Effect.gen(function* () {
+          yield* Effect.log("🏈 PLL Full Extraction");
+          yield* Effect.log(`Output directory: ${config.outputDir}`);
+
+          for (const year of PLL_YEARS) {
+            yield* extractYear(year, options);
+            yield* Effect.sleep(Duration.millis(config.delayBetweenBatchesMs));
+          }
+
+          const manifest = yield* manifestService.load;
+          yield* Effect.log("\n" + "=".repeat(50));
+          yield* Effect.log("EXTRACTION COMPLETE");
+          yield* Effect.log("=".repeat(50));
+
+          return manifest;
+        });
+
+      return {
+        extractTeams,
+        extractTeamDetails,
+        extractPlayers,
+        extractAdvancedPlayers,
+        extractPlayerDetails,
+        extractEvents,
+        extractEventDetails,
+        extractStandings,
+        extractStandingsCS,
+        extractYear,
+        extractAll,
+        PLL_YEARS,
+      };
+    }),
+    dependencies: [
+      PLLClient.Default,
+      ExtractConfigService.Default,
+      PLLManifestService.Default,
+    ],
+  },
+) {}

--- a/packages/pipeline/src/extract/pll/pll.manifest.ts
+++ b/packages/pipeline/src/extract/pll/pll.manifest.ts
@@ -1,0 +1,125 @@
+import { Effect, Schema } from "effect";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+  type ExtractionManifest,
+  type SeasonManifest,
+  type EntityStatus,
+  ExtractionManifest as ExtractionManifestSchema,
+  createEmptyManifest,
+  createEmptySeasonManifest,
+} from "../extract.schema";
+import { ExtractConfigService } from "../extract.config";
+
+export class PLLManifestService extends Effect.Service<PLLManifestService>()(
+  "PLLManifestService",
+  {
+    effect: Effect.gen(function* () {
+      const config = yield* ExtractConfigService;
+      const manifestPath = path.join(config.outputDir, "pll", "manifest.json");
+
+      const load = Effect.gen(function* () {
+        const exists = yield* Effect.tryPromise({
+          try: () =>
+            fs
+              .access(manifestPath)
+              .then(() => true)
+              .catch(() => false),
+          catch: () => new Error("Unexpected error checking file existence"),
+        });
+
+        if (!exists) {
+          return createEmptyManifest("pll");
+        }
+
+        const content = yield* Effect.tryPromise({
+          try: () => fs.readFile(manifestPath, "utf-8"),
+          catch: (e) => new Error(`Failed to read manifest: ${String(e)}`),
+        });
+
+        const parsed = JSON.parse(content);
+        return yield* Schema.decode(ExtractionManifestSchema)(parsed).pipe(
+          Effect.catchAll(() => Effect.succeed(createEmptyManifest("pll"))),
+        );
+      });
+
+      const save = (manifest: ExtractionManifest) =>
+        Effect.gen(function* () {
+          const dir = path.dirname(manifestPath);
+          yield* Effect.tryPromise({
+            try: () => fs.mkdir(dir, { recursive: true }),
+            catch: (e) => new Error(`Failed to create directory: ${String(e)}`),
+          });
+
+          const content = JSON.stringify(manifest, null, 2);
+          yield* Effect.tryPromise({
+            try: () => fs.writeFile(manifestPath, content),
+            catch: (e) => new Error(`Failed to write manifest: ${String(e)}`),
+          });
+        });
+
+      const getSeasonManifest = (
+        manifest: ExtractionManifest,
+        year: number,
+      ): SeasonManifest => {
+        const key = String(year);
+        return manifest.seasons[key] ?? createEmptySeasonManifest();
+      };
+
+      const updateEntityStatus = (
+        manifest: ExtractionManifest,
+        year: number,
+        entity: keyof SeasonManifest,
+        status: EntityStatus,
+      ): ExtractionManifest => {
+        const key = String(year);
+        const seasonManifest = getSeasonManifest(manifest, year);
+        return {
+          ...manifest,
+          seasons: {
+            ...manifest.seasons,
+            [key]: {
+              ...seasonManifest,
+              [entity]: status,
+            },
+          },
+          lastRun: new Date().toISOString(),
+        };
+      };
+
+      const markComplete = (
+        manifest: ExtractionManifest,
+        year: number,
+        entity: keyof SeasonManifest,
+        count: number,
+        durationMs: number,
+      ): ExtractionManifest => {
+        return updateEntityStatus(manifest, year, entity, {
+          extracted: true,
+          count,
+          timestamp: new Date().toISOString(),
+          durationMs,
+        });
+      };
+
+      const isExtracted = (
+        manifest: ExtractionManifest,
+        year: number,
+        entity: keyof SeasonManifest,
+      ): boolean => {
+        const seasonManifest = getSeasonManifest(manifest, year);
+        return seasonManifest[entity].extracted;
+      };
+
+      return {
+        load,
+        save,
+        getSeasonManifest,
+        updateEntityStatus,
+        markComplete,
+        isExtracted,
+      };
+    }),
+    dependencies: [ExtractConfigService.Default],
+  },
+) {}

--- a/packages/pipeline/src/extract/run.ts
+++ b/packages/pipeline/src/extract/run.ts
@@ -1,0 +1,113 @@
+/**
+ * PLL Data Extraction CLI
+ *
+ * Usage:
+ *   infisical run --env=dev -- bun src/extract/run.ts --all
+ *   infisical run --env=dev -- bun src/extract/run.ts --year=2024
+ *   infisical run --env=dev -- bun src/extract/run.ts --year=2024 --no-details
+ *   infisical run --env=dev -- bun src/extract/run.ts --year=2024 --force
+ */
+
+import { Effect, Layer } from "effect";
+import { PLLExtractorService, PLLManifestService } from "./pll";
+import { ExtractConfigService } from "./extract.config";
+import { PLLClient } from "../pll/pll.client";
+
+interface CliArgs {
+  all: boolean;
+  year: number | null;
+  includeDetails: boolean;
+  force: boolean;
+  help: boolean;
+}
+
+const parseArgs = (): CliArgs => {
+  const args = process.argv.slice(2);
+
+  const yearArg = args.find((a) => a.startsWith("--year="));
+  const year = yearArg ? parseInt(yearArg.split("=")[1]!, 10) : null;
+
+  return {
+    all: args.includes("--all"),
+    year,
+    includeDetails: !args.includes("--no-details"),
+    force: args.includes("--force"),
+    help: args.includes("--help") || args.includes("-h"),
+  };
+};
+
+const printHelp = () => {
+  console.log(`
+PLL Data Extraction CLI
+
+Usage:
+  bun src/extract/run.ts [options]
+
+Options:
+  --all           Extract all years (2019-2025)
+  --year=YYYY     Extract specific year
+  --no-details    Skip detail endpoints (faster)
+  --force         Re-extract even if already done
+  --help, -h      Show this help
+
+Examples:
+  infisical run --env=dev -- bun src/extract/run.ts --all
+  infisical run --env=dev -- bun src/extract/run.ts --year=2024
+  infisical run --env=dev -- bun src/extract/run.ts --year=2024 --no-details
+  infisical run --env=dev -- bun src/extract/run.ts --all --force
+`);
+};
+
+const runExtraction = (args: CliArgs) =>
+  Effect.gen(function* () {
+    const extractor = yield* PLLExtractorService;
+    const options = {
+      includeDetails: args.includeDetails,
+      skipExisting: !args.force,
+    };
+
+    if (args.all) {
+      yield* extractor.extractAll(options);
+    } else if (args.year) {
+      if (args.year < 2019 || args.year > 2030) {
+        return yield* Effect.fail(
+          `Invalid year ${args.year}. Must be 2019-2030.`,
+        );
+      }
+      yield* extractor.extractYear(args.year, options);
+    }
+  });
+
+const MainLive = Layer.mergeAll(
+  PLLClient.Default,
+  ExtractConfigService.Default,
+).pipe(
+  Layer.provideMerge(PLLManifestService.Default),
+  Layer.provideMerge(PLLExtractorService.Default),
+);
+
+const main = async () => {
+  const args = parseArgs();
+
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  if (!args.all && !args.year) {
+    console.error("Error: Must specify --all or --year=YYYY");
+    printHelp();
+    process.exit(1);
+  }
+
+  const program = runExtraction(args).pipe(Effect.provide(MainLive));
+
+  try {
+    await Effect.runPromise(program);
+  } catch (error) {
+    console.error("Extraction failed:", error);
+    process.exit(1);
+  }
+};
+
+void main();

--- a/packages/pipeline/src/extract/sample-player-details.ts
+++ b/packages/pipeline/src/extract/sample-player-details.ts
@@ -1,0 +1,241 @@
+/**
+ * Sample Player Details Extraction
+ *
+ * Extracts player details for a small sample to understand the data structure
+ * before committing to full extraction (~200 players per year).
+ *
+ * Usage:
+ *   infisical run --env=dev -- bun src/extract/sample-player-details.ts
+ *   infisical run --env=dev -- bun src/extract/sample-player-details.ts --count=10
+ *   infisical run --env=dev -- bun src/extract/sample-player-details.ts --year=2024 --count=5
+ */
+
+import { Effect, Duration } from "effect";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { PLLClient } from "../pll/pll.client";
+import type { PLLPlayer, PLLPlayerDetail } from "../pll/pll.schema";
+import { ExtractConfigService } from "./extract.config";
+
+const args = process.argv.slice(2);
+const yearArg = args.find((a) => a.startsWith("--year="));
+const countArg = args.find((a) => a.startsWith("--count="));
+
+const YEAR = yearArg ? parseInt(yearArg.split("=")[1]!, 10) : 2024;
+const SAMPLE_COUNT = countArg ? parseInt(countArg.split("=")[1]!, 10) : 5;
+
+const program = Effect.gen(function* () {
+  const pll = yield* PLLClient;
+  const config = yield* ExtractConfigService;
+
+  yield* Effect.log(`\n${"=".repeat(60)}`);
+  yield* Effect.log(`Player Detail Sample Extraction`);
+  yield* Effect.log(`Year: ${YEAR}, Sample size: ${SAMPLE_COUNT}`);
+  yield* Effect.log("=".repeat(60) + "\n");
+
+  // Load existing players
+  const playersPath = path.join(
+    config.outputDir,
+    "pll",
+    String(YEAR),
+    "players.json",
+  );
+
+  yield* Effect.log(`Loading players from ${playersPath}...`);
+
+  const playersData = yield* Effect.tryPromise({
+    try: () => fs.readFile(playersPath, "utf-8"),
+    catch: (e) => new Error(`Failed to read players file: ${String(e)}`),
+  });
+
+  const allPlayers = JSON.parse(playersData) as PLLPlayer[];
+  yield* Effect.log(`Found ${allPlayers.length} players\n`);
+
+  // Filter players with slugs and sample
+  const playersWithSlug = allPlayers.filter((p) => p.slug !== null);
+
+  // Get a diverse sample: high performers, different positions
+  const samplePlayers = playersWithSlug
+    .filter((p) => (p.stats?.gamesPlayed ?? 0) >= 5) // Players with actual playing time
+    .toSorted((a, b) => (b.stats?.goals ?? 0) - (a.stats?.goals ?? 0)) // Sort by goals
+    .slice(0, Math.min(SAMPLE_COUNT * 3, playersWithSlug.length)) // Take top performers pool
+    .toSorted(() => Math.random() - 0.5) // Shuffle
+    .slice(0, SAMPLE_COUNT); // Take sample
+
+  yield* Effect.log(`Selected ${samplePlayers.length} players for sampling:\n`);
+  for (const p of samplePlayers) {
+    yield* Effect.log(
+      `  - ${p.firstName} ${p.lastName} (${p.allTeams[0]?.position ?? "?"}) - ${p.stats?.goals ?? 0} goals, ${p.stats?.gamesPlayed ?? 0} GP`,
+    );
+  }
+  yield* Effect.log("");
+
+  // Extract details for each
+  const details: Array<{
+    player: PLLPlayer;
+    detail: PLLPlayerDetail | null;
+    error: string | null;
+  }> = [];
+
+  for (const player of samplePlayers) {
+    if (!player.slug) continue;
+
+    yield* Effect.log(
+      `Fetching detail for ${player.firstName} ${player.lastName}...`,
+    );
+
+    const result = yield* pll
+      .getPlayerDetail({
+        slug: player.slug,
+        year: YEAR,
+        statsYear: YEAR,
+      })
+      .pipe(
+        Effect.map((detail) => ({
+          player,
+          detail,
+          error: null as string | null,
+        })),
+        Effect.catchAll((e) =>
+          Effect.succeed({
+            player,
+            detail: null as PLLPlayerDetail | null,
+            error: String(e),
+          }),
+        ),
+        Effect.tap(() => Effect.sleep(Duration.millis(200))),
+      );
+
+    details.push(result);
+  }
+
+  // Save sample output
+  const outputPath = path.join(
+    config.outputDir,
+    "pll",
+    "samples",
+    `player-details-sample-${YEAR}.json`,
+  );
+
+  const outputDir = path.dirname(outputPath);
+  yield* Effect.tryPromise({
+    try: () => fs.mkdir(outputDir, { recursive: true }),
+    catch: (e) => new Error(`Failed to create directory: ${String(e)}`),
+  });
+
+  yield* Effect.tryPromise({
+    try: () => fs.writeFile(outputPath, JSON.stringify(details, null, 2)),
+    catch: (e) => new Error(`Failed to write file: ${String(e)}`),
+  });
+
+  yield* Effect.log(`\nSaved sample to ${outputPath}\n`);
+
+  // Analyze the data structure
+  yield* Effect.log("=".repeat(60));
+  yield* Effect.log(`DATA STRUCTURE ANALYSIS`);
+  yield* Effect.log("=".repeat(60) + "\n");
+
+  const successfulDetails = details.filter((d) => d.detail !== null);
+
+  if (successfulDetails.length === 0) {
+    yield* Effect.log("No successful detail fetches. Check errors above.");
+    return;
+  }
+
+  const firstDetail = successfulDetails[0]!.detail!;
+
+  yield* Effect.log(
+    `Sample player: ${successfulDetails[0]!.player.firstName} ${successfulDetails[0]!.player.lastName}\n`,
+  );
+
+  // careerStats
+  if (firstDetail.careerStats) {
+    yield* Effect.log(`careerStats: PRESENT`);
+    const fields = Object.keys(firstDetail.careerStats);
+    yield* Effect.log(`  Fields (${fields.length}): ${fields.join(", ")}`);
+  } else {
+    yield* Effect.log(`careerStats: NULL`);
+  }
+
+  // allSeasonStats
+  yield* Effect.log(
+    `\nallSeasonStats: ${firstDetail.allSeasonStats.length} entries`,
+  );
+  if (firstDetail.allSeasonStats.length > 0) {
+    const entry = firstDetail.allSeasonStats[0]!;
+    yield* Effect.log(
+      `  Sample entry: year=${entry.year}, segment=${entry.seasonSegment}, teamId=${entry.teamId}`,
+    );
+    yield* Effect.log(`  Fields: ${Object.keys(entry).join(", ")}`);
+
+    // Show all years/segments
+    const yearSegments = firstDetail.allSeasonStats.map(
+      (s) => `${s.year}-${s.seasonSegment}`,
+    );
+    yield* Effect.log(`  All entries: ${yearSegments.join(", ")}`);
+  }
+
+  // accolades
+  yield* Effect.log(`\naccolades: ${firstDetail.accolades.length} entries`);
+  if (firstDetail.accolades.length > 0) {
+    for (const acc of firstDetail.accolades) {
+      yield* Effect.log(`  - ${acc.awardName}: ${acc.years.join(", ")}`);
+    }
+  }
+
+  // advancedSeasonStats
+  if (firstDetail.advancedSeasonStats) {
+    yield* Effect.log(`\nadvancedSeasonStats: PRESENT`);
+    const fields = Object.keys(firstDetail.advancedSeasonStats);
+    yield* Effect.log(`  Fields (${fields.length}): ${fields.join(", ")}`);
+  } else {
+    yield* Effect.log(`\nadvancedSeasonStats: NULL`);
+  }
+
+  // champSeries
+  if (firstDetail.champSeries) {
+    yield* Effect.log(`\nchampSeries: PRESENT`);
+    yield* Effect.log(`  position: ${firstDetail.champSeries.position}`);
+    yield* Effect.log(
+      `  team: ${firstDetail.champSeries.team?.officialId ?? "null"}`,
+    );
+    yield* Effect.log(
+      `  stats: ${firstDetail.champSeries.stats ? "PRESENT" : "NULL"}`,
+    );
+  } else {
+    yield* Effect.log(`\nchampSeries: NULL`);
+  }
+
+  // Summary
+  yield* Effect.log(`\n${"=".repeat(60)}`);
+  yield* Effect.log(`SUMMARY`);
+  yield* Effect.log("=".repeat(60));
+  yield* Effect.log(
+    `Fetched: ${successfulDetails.length}/${details.length} successful`,
+  );
+  yield* Effect.log(`Output: ${outputPath}`);
+  yield* Effect.log(``);
+
+  // Value assessment
+  yield* Effect.log(`VALUE ASSESSMENT:`);
+  yield* Effect.log(
+    `  - careerStats: Lifetime totals (useful for career leaderboards)`,
+  );
+  yield* Effect.log(
+    `  - allSeasonStats: Per-year stats (already have via list endpoint for current year)`,
+  );
+  yield* Effect.log(
+    `  - accolades: Awards (All-Star, MVP, etc.) - UNIQUE to detail endpoint`,
+  );
+  yield* Effect.log(
+    `  - advancedSeasonStats: Advanced metrics (may be same as getAdvancedPlayers)`,
+  );
+  yield* Effect.log(``);
+});
+
+Effect.runPromise(
+  program.pipe(
+    Effect.provide(PLLClient.Default),
+    Effect.provide(ExtractConfigService.Default),
+  ),
+).catch(console.error);

--- a/packages/pipeline/src/pll/explore-data.ts
+++ b/packages/pipeline/src/pll/explore-data.ts
@@ -1,0 +1,416 @@
+/**
+ * PLL Data Exploration Script
+ *
+ * Usage:
+ *   infisical run --env=dev -- bun src/pll/explore-data.ts
+ *   infisical run --env=dev -- bun src/pll/explore-data.ts --year=2024
+ *   infisical run --env=dev -- bun src/pll/explore-data.ts --full
+ */
+
+import { Effect, Duration } from "effect";
+import { PLLClient } from "./pll.client";
+import type { PLLPlayer, PLLTeam, PLLEvent } from "./pll.schema";
+
+const PLL_YEARS = [2019, 2020, 2021, 2022, 2023, 2024, 2025] as const;
+
+interface YearSummary {
+  year: number;
+  teams: { count: number; withStats: number; withCoaches: number };
+  players: { count: number; withStats: number; withAllTeams: number };
+  events: { count: number; completed: number; withScores: number };
+  standings: { count: number };
+  timing: { teamsMs: number; playersMs: number; eventsMs: number };
+}
+
+interface FieldAnalysis {
+  field: string;
+  populated: number;
+  total: number;
+  percentage: number;
+}
+
+const analyzeFields = <T>(
+  items: readonly T[],
+  fields: (keyof T)[],
+): FieldAnalysis[] => {
+  return fields.map((field) => {
+    const populated = items.filter((item) => {
+      const value = item[field];
+      return value !== null && value !== undefined;
+    }).length;
+    return {
+      field: String(field),
+      populated,
+      total: items.length,
+      percentage:
+        items.length > 0 ? Math.round((populated / items.length) * 100) : 0,
+    };
+  });
+};
+
+const formatMs = (ms: number): string => {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+};
+
+const exploreYear = (year: number) =>
+  Effect.gen(function* () {
+    const pll = yield* PLLClient;
+    yield* Effect.log(`\n${"=".repeat(60)}`);
+    yield* Effect.log(`Exploring PLL ${year}`);
+    yield* Effect.log("=".repeat(60));
+
+    const summary: YearSummary = {
+      year,
+      teams: { count: 0, withStats: 0, withCoaches: 0 },
+      players: { count: 0, withStats: 0, withAllTeams: 0 },
+      events: { count: 0, completed: 0, withScores: 0 },
+      standings: { count: 0 },
+      timing: { teamsMs: 0, playersMs: 0, eventsMs: 0 },
+    };
+
+    yield* Effect.log("\n📊 Teams:");
+    const teamsStart = Date.now();
+    const teams = yield* pll
+      .getTeams({ year, includeChampSeries: true })
+      .pipe(Effect.catchAll(() => Effect.succeed([] as readonly PLLTeam[])));
+    summary.timing.teamsMs = Date.now() - teamsStart;
+    summary.teams.count = teams.length;
+    summary.teams.withStats = teams.filter((t) => t.stats !== null).length;
+    summary.teams.withCoaches = teams.filter(
+      (t) => t.coaches.length > 0,
+    ).length;
+
+    yield* Effect.log(`   Count: ${teams.length}`);
+    yield* Effect.log(`   With stats: ${summary.teams.withStats}`);
+    yield* Effect.log(`   With coaches: ${summary.teams.withCoaches}`);
+    yield* Effect.log(`   Fetch time: ${formatMs(summary.timing.teamsMs)}`);
+
+    if (teams.length > 0) {
+      const teamFields = analyzeFields(teams, [
+        "officialId",
+        "locationCode",
+        "location",
+        "fullName",
+        "urlLogo",
+        "slogan",
+        "stats",
+        "postStats",
+        "champSeries",
+      ]);
+      yield* Effect.log("   Field completeness:");
+      for (const f of teamFields.filter((f) => f.percentage < 100)) {
+        yield* Effect.log(
+          `     - ${f.field}: ${f.percentage}% (${f.populated}/${f.total})`,
+        );
+      }
+    }
+
+    yield* Effect.log("\n👥 Players:");
+    const playersStart = Date.now();
+    const players = yield* pll
+      .getPlayers({
+        season: year,
+        limit: 500,
+      })
+      .pipe(
+        Effect.catchAll((e) => {
+          return Effect.gen(function* () {
+            yield* Effect.log(`     ⚠️ Error fetching players: ${String(e)}`);
+            return [] as readonly PLLPlayer[];
+          });
+        }),
+      );
+    summary.timing.playersMs = Date.now() - playersStart;
+    summary.players.count = players.length;
+    summary.players.withStats = players.filter(
+      (p) => p.stats !== undefined,
+    ).length;
+    summary.players.withAllTeams = players.filter(
+      (p) => p.allTeams.length > 0,
+    ).length;
+
+    yield* Effect.log(`   Count: ${players.length}`);
+    yield* Effect.log(`   With stats: ${summary.players.withStats}`);
+    yield* Effect.log(`   With team history: ${summary.players.withAllTeams}`);
+    yield* Effect.log(`   Fetch time: ${formatMs(summary.timing.playersMs)}`);
+
+    if (players.length > 0) {
+      const playerFields = analyzeFields(players, [
+        "officialId",
+        "firstName",
+        "lastName",
+        "slug",
+        "profileUrl",
+        "handedness",
+        "country",
+        "experience",
+        "isCaptain",
+        "injuryStatus",
+        "stats",
+        "postStats",
+        "champSeries",
+      ]);
+      yield* Effect.log("   Field completeness:");
+      for (const f of playerFields.filter((f) => f.percentage < 100)) {
+        yield* Effect.log(
+          `     - ${f.field}: ${f.percentage}% (${f.populated}/${f.total})`,
+        );
+      }
+
+      const positions = new Map<string, number>();
+      for (const p of players) {
+        const team = p.allTeams.find((t) => t.year === year);
+        const pos = team?.positionName ?? "Unknown";
+        positions.set(pos, (positions.get(pos) ?? 0) + 1);
+      }
+      yield* Effect.log("   Positions:");
+      for (const [pos, count] of [...positions.entries()].toSorted(
+        (a, b) => b[1] - a[1],
+      )) {
+        yield* Effect.log(`     - ${pos}: ${count}`);
+      }
+    }
+
+    yield* Effect.log("\n🎮 Events:");
+    const eventsStart = Date.now();
+    const events = yield* pll
+      .getEvents({ year })
+      .pipe(Effect.catchAll(() => Effect.succeed([] as readonly PLLEvent[])));
+    summary.timing.eventsMs = Date.now() - eventsStart;
+    summary.events.count = events.length;
+    summary.events.completed = events.filter((e) => e.eventStatus === 3).length;
+    summary.events.withScores = events.filter(
+      (e) => e.homeScore !== null && e.visitorScore !== null,
+    ).length;
+
+    yield* Effect.log(`   Count: ${events.length}`);
+    yield* Effect.log(`   Completed: ${summary.events.completed}`);
+    yield* Effect.log(`   With scores: ${summary.events.withScores}`);
+    yield* Effect.log(`   Fetch time: ${formatMs(summary.timing.eventsMs)}`);
+
+    if (events.length > 0) {
+      const eventFields = analyzeFields(events, [
+        "slugname",
+        "startTime",
+        "venue",
+        "homeTeam",
+        "awayTeam",
+        "homeScore",
+        "visitorScore",
+        "broadcaster",
+        "eventStatus",
+      ]);
+      yield* Effect.log("   Field completeness:");
+      for (const f of eventFields.filter((f) => f.percentage < 100)) {
+        yield* Effect.log(
+          `     - ${f.field}: ${f.percentage}% (${f.populated}/${f.total})`,
+        );
+      }
+
+      const statuses = new Map<number | null, number>();
+      for (const e of events) {
+        statuses.set(e.eventStatus, (statuses.get(e.eventStatus) ?? 0) + 1);
+      }
+      yield* Effect.log("   Event statuses:");
+      const statusNames: Record<number, string> = {
+        1: "Scheduled",
+        2: "In Progress",
+        3: "Final",
+        4: "Cancelled",
+        5: "Postponed",
+      };
+      for (const [status, count] of [...statuses.entries()].toSorted(
+        (a, b) => (a[0] ?? 0) - (b[0] ?? 0),
+      )) {
+        const name = status
+          ? (statusNames[status] ?? `Unknown(${status})`)
+          : "null";
+        yield* Effect.log(`     - ${name}: ${count}`);
+      }
+    }
+
+    yield* Effect.log("\n📈 Standings:");
+    const standings = yield* pll
+      .getStandings({ year, champSeries: false })
+      .pipe(Effect.catchAll(() => Effect.succeed([])));
+    summary.standings.count = standings.length;
+    yield* Effect.log(`   Count: ${standings.length}`);
+
+    return summary;
+  });
+
+const exploreDetailEndpoints = (year: number) =>
+  Effect.gen(function* () {
+    const pll = yield* PLLClient;
+    yield* Effect.log(`\n${"=".repeat(60)}`);
+    yield* Effect.log(`Exploring Detail Endpoints for ${year}`);
+    yield* Effect.log("=".repeat(60));
+
+    const teams = yield* pll
+      .getTeams({ year })
+      .pipe(Effect.catchAll(() => Effect.succeed([] as readonly PLLTeam[])));
+
+    if (teams.length === 0) {
+      yield* Effect.log("No teams found, skipping detail exploration");
+      return;
+    }
+
+    const sampleTeam = teams[0]!;
+    yield* Effect.log(`\n🏟️ Team Detail (${sampleTeam.fullName}):`);
+    const teamDetailStart = Date.now();
+    const teamDetail = yield* pll
+      .getTeamDetail({
+        id: sampleTeam.officialId,
+        year,
+        statsYear: year,
+        eventsYear: year,
+        includeChampSeries: true,
+      })
+      .pipe(Effect.catchAll(() => Effect.succeed(null)));
+    const teamDetailMs = Date.now() - teamDetailStart;
+
+    if (teamDetail) {
+      yield* Effect.log(`   Fetch time: ${formatMs(teamDetailMs)}`);
+      yield* Effect.log(`   Events: ${teamDetail.events.length}`);
+      yield* Effect.log(`   Coaches: ${teamDetail.coaches.length}`);
+      yield* Effect.log(`   All years: ${teamDetail.allYears.join(", ")}`);
+      yield* Effect.log(`   Has stats: ${teamDetail.stats !== null}`);
+      yield* Effect.log(`   Has post stats: ${teamDetail.postStats !== null}`);
+      yield* Effect.log(
+        `   Has champSeries: ${teamDetail.champSeries !== undefined}`,
+      );
+    }
+
+    const players = yield* pll
+      .getPlayers({ season: year, limit: 10 })
+      .pipe(Effect.catchAll(() => Effect.succeed([] as readonly PLLPlayer[])));
+
+    if (players.length > 0) {
+      const samplePlayer = players[0]!;
+      const slug = samplePlayer.slug;
+      if (slug) {
+        yield* Effect.log(
+          `\n👤 Player Detail (${samplePlayer.firstName} ${samplePlayer.lastName}):`,
+        );
+        const playerDetailStart = Date.now();
+        const playerDetail = yield* pll
+          .getPlayerDetail({
+            slug,
+            year,
+            statsYear: year,
+          })
+          .pipe(Effect.catchAll(() => Effect.succeed(null)));
+        const playerDetailMs = Date.now() - playerDetailStart;
+
+        if (playerDetail) {
+          yield* Effect.log(`   Fetch time: ${formatMs(playerDetailMs)}`);
+          yield* Effect.log(
+            `   All season stats: ${playerDetail.allSeasonStats.length}`,
+          );
+          yield* Effect.log(`   Accolades: ${playerDetail.accolades.length}`);
+          yield* Effect.log(
+            `   Has career stats: ${playerDetail.careerStats !== null}`,
+          );
+          yield* Effect.log(
+            `   Has advanced stats: ${playerDetail.advancedSeasonStats !== null}`,
+          );
+
+          const seasons = [
+            ...new Set(playerDetail.allSeasonStats.map((s) => s.year)),
+          ].toSorted((a, b) => a - b);
+          yield* Effect.log(`   Seasons with stats: ${seasons.join(", ")}`);
+        }
+      }
+    }
+
+    const events = yield* pll
+      .getEvents({ year })
+      .pipe(Effect.catchAll(() => Effect.succeed([] as readonly PLLEvent[])));
+
+    const completedEvent = events.find(
+      (e) => e.eventStatus === 3 && e.slugname,
+    );
+    if (completedEvent?.slugname) {
+      yield* Effect.log(`\n🎮 Event Detail (${completedEvent.slugname}):`);
+      const eventDetailStart = Date.now();
+      const eventDetail = yield* pll
+        .getEventDetail({ slug: completedEvent.slugname })
+        .pipe(Effect.catchAll(() => Effect.succeed(null)));
+      const eventDetailMs = Date.now() - eventDetailStart;
+
+      if (eventDetail) {
+        yield* Effect.log(`   Fetch time: ${formatMs(eventDetailMs)}`);
+        yield* Effect.log(
+          `   Score: ${eventDetail.homeTeam?.locationCode ?? "?"} ${eventDetail.homeScore} - ${eventDetail.visitorScore} ${eventDetail.awayTeam?.locationCode ?? "?"}`,
+        );
+        yield* Effect.log(`   Play logs: ${eventDetail.playLogs?.length ?? 0}`);
+        yield* Effect.log(`   Period: ${eventDetail.period}`);
+      }
+    }
+  });
+
+const main = Effect.gen(function* () {
+  const args = process.argv.slice(2);
+  const yearArg = args.find((a) => a.startsWith("--year="));
+  const fullMode = args.includes("--full");
+  const detailMode = args.includes("--detail");
+
+  yield* Effect.log("🏈 PLL Data Exploration");
+  yield* Effect.log("========================\n");
+
+  const summaries: YearSummary[] = [];
+
+  if (yearArg) {
+    const year = parseInt(yearArg.split("=")[1]!, 10);
+    if (year < 2019 || year > 2030) {
+      yield* Effect.log(`Invalid year: ${year}. Must be 2019-2030.`);
+      return;
+    }
+    const summary = yield* exploreYear(year);
+    summaries.push(summary);
+
+    if (detailMode || fullMode) {
+      yield* exploreDetailEndpoints(year);
+    }
+  } else {
+    for (const year of PLL_YEARS) {
+      const summary = yield* exploreYear(year);
+      summaries.push(summary);
+      yield* Effect.sleep(Duration.millis(500));
+    }
+
+    if (fullMode) {
+      yield* exploreDetailEndpoints(2024);
+    }
+  }
+
+  yield* Effect.log(`\n${"=".repeat(60)}`);
+  yield* Effect.log("SUMMARY");
+  yield* Effect.log("=".repeat(60));
+  yield* Effect.log("\nYear | Teams | Players | Events | Standings");
+  yield* Effect.log("-----|-------|---------|--------|----------");
+  for (const s of summaries) {
+    yield* Effect.log(
+      `${s.year} | ${String(s.teams.count).padStart(5)} | ${String(s.players.count).padStart(7)} | ${String(s.events.count).padStart(6)} | ${String(s.standings.count).padStart(9)}`,
+    );
+  }
+
+  yield* Effect.log("\nAPI Response Times (ms):");
+  yield* Effect.log("Year | Teams  | Players | Events");
+  yield* Effect.log("-----|--------|---------|-------");
+  for (const s of summaries) {
+    yield* Effect.log(
+      `${s.year} | ${String(s.timing.teamsMs).padStart(6)} | ${String(s.timing.playersMs).padStart(7)} | ${String(s.timing.eventsMs).padStart(6)}`,
+    );
+  }
+
+  yield* Effect.log("\n✅ Exploration complete!");
+});
+
+try {
+  await Effect.runPromise(main.pipe(Effect.provide(PLLClient.Default)));
+} catch (error) {
+  console.error("Failed:", error);
+  process.exit(1);
+}

--- a/packages/pipeline/src/pll/pll.schema.ts
+++ b/packages/pipeline/src/pll/pll.schema.ts
@@ -167,7 +167,7 @@ export class PLLPlayer extends Schema.Class<PLLPlayer>("PLLPlayer")({
   allTeams: Schema.Array(PLLPlayerTeam),
   stats: Schema.optional(PLLPlayerStats),
   postStats: Schema.optional(PLLPlayerStats),
-  champSeries: Schema.optional(PLLChampSeries),
+  champSeries: Schema.NullishOr(PLLChampSeries),
 }) {}
 
 export class PLLPlayersResponse extends Schema.Class<PLLPlayersResponse>(


### PR DESCRIPTION
## Summary
Implements a comprehensive data extraction system for PLL (Premier Lacrosse League) API endpoints, enabling systematic collection of teams, players, events, standings, and detailed statistics across all seasons (2019-2025) with manifest-based tracking and configurable extraction options.

## Changes
- Add comprehensive PLL data model documentation mapping all entities, relationships, and API endpoints
- Implement extraction framework with config service for output directory, concurrency, and rate limiting
- Create manifest system for tracking extraction status per season/entity with skip logic
- Build PLLExtractorService with methods for teams, players, events, standings, and their detail endpoints
- Add CLI runner with year-specific and full extraction modes with progress logging
- Configure gitignore to exclude pipeline output directory
- Include sample exploration scripts for player detail endpoint analysis

## Type
- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other

## Notes
This extraction framework provides the foundation for building a complete PLL database. The system includes rate limiting (100ms between requests, 500ms between batches), manifest-based incremental extraction to avoid re-fetching data, and comprehensive error handling with logging. The data model document serves as the schema planning reference before database design.

---
*Auto-generated by Claude. Feel free to edit.*