### PR TITLE
feat(pipeline): add validation framework for PLL data extraction

### DIFF
--- a/packages/pipeline/AGENTS.md
+++ b/packages/pipeline/AGENTS.md
@@ -276,6 +276,52 @@ infisical run --env=dev -- bun src/example-pll.ts   # Run PLL example
 infisical run --env=dev -- bun run test             # Run tests
 bun run typecheck                                    # Type check
 bun run fix                                          # Lint + format
+
+# Data extraction
+infisical run --env=dev -- bun src/extract/extract-all-player-details.ts
+infisical run --env=dev -- bun src/extract/extract-remaining.ts
+infisical run --env=dev -- bun src/extract/extract-career-stats.ts
+
+# Data validation
+infisical run --env=dev -- bun src/validate/validate-pll.ts
+```
+
+## VALIDATION
+
+The `src/validate/` module provides reusable validators for extracted data.
+
+### Running Validation
+
+```bash
+infisical run --env=dev -- bun src/validate/validate-pll.ts
+```
+
+### Validation Checks
+
+| Check | Description |
+|-------|-------------|
+| `file_exists` | Verifies file exists and captures size |
+| `json_parse` | Validates JSON structure and record count |
+| `required_fields` | Checks for null/undefined required fields |
+| `unique_field` | Detects duplicate values in ID fields |
+| `cross_reference` | Validates foreign key relationships between datasets |
+
+### Validation Report
+
+Outputs a JSON report to `output/pll/validation-report.json` with:
+- File-level checks and issues
+- Cross-reference match rates
+- Summary statistics (errors, warnings, info)
+- Overall validity status
+
+### Adding New Validators
+
+```typescript
+import { validateJsonArray, validateRequiredFields, crossReference } from "./validate.service";
+
+const { result, data } = yield* validateJsonArray<MyType>(filePath, minRecords);
+const fieldCheck = yield* validateRequiredFields(data, ["id", "name"]);
+const xref = yield* crossReference(sourceData, targetData, "foreignKey", "id", "source.json", "target.json");
 ```
 
 ## PLL API REFERENCE

--- a/packages/pipeline/src/validate/index.ts
+++ b/packages/pipeline/src/validate/index.ts
@@ -1,0 +1,11 @@
+export * from "./validate.schema";
+export {
+  validateFileExists,
+  validateJsonArray,
+  validateSchema,
+  validateRequiredFields,
+  validateUniqueField,
+  crossReference,
+  buildReport,
+  printReport,
+} from "./validate.service";

--- a/packages/pipeline/src/validate/validate-pll.ts
+++ b/packages/pipeline/src/validate/validate-pll.ts
@@ -1,0 +1,335 @@
+import { Effect } from "effect";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import { ExtractConfigService } from "../extract/extract.config";
+import {
+  validateJsonArray,
+  validateRequiredFields,
+  validateUniqueField,
+  crossReference,
+  buildReport,
+  printReport,
+  validateFileExists,
+} from "./validate.service";
+import type {
+  FileValidationResult,
+  CrossReferenceResult,
+  ValidationCheckResult,
+} from "./validate.schema";
+import { errorIssue, infoIssue } from "./validate.schema";
+
+interface PlayerDetail {
+  slug: string;
+  officialId: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface CareerStatsPlayer {
+  slug: string | null;
+  name: string;
+  experience: number | null;
+  allYears: number[] | null;
+  stats: {
+    gamesPlayed: number;
+    points: number;
+    goals: number;
+    assists: number;
+    groundBalls: number;
+    saves: number;
+    faceoffsWon: number;
+  };
+  inPlayerDetails: boolean;
+  likelySource: "pll" | "mll_or_retired";
+}
+
+interface EventDetailWrapper {
+  slug: string;
+  year: number;
+  detail: {
+    id: number;
+    homeTeam: { officialId: string } | null;
+    awayTeam: { officialId: string } | null;
+    playLogs: unknown[] | null;
+  };
+}
+
+interface TeamDetailWrapper {
+  teamId: string;
+  year: number;
+  detail: {
+    officialId: string;
+    fullName: string;
+    coaches: unknown[];
+  };
+}
+
+type StatLeadersData = Record<string, Record<string, unknown[]>>;
+
+const YEARS = [2019, 2020, 2021, 2022, 2023, 2024, 2025];
+
+const readJsonFile = <T>(filePath: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const content = await fs.readFile(filePath, "utf-8");
+      return JSON.parse(content) as T;
+    },
+    catch: (e) => new Error(`Failed to read ${filePath}: ${String(e)}`),
+  });
+
+const program = Effect.gen(function* () {
+  const config = yield* ExtractConfigService;
+  const pllDir = path.join(config.outputDir, "pll");
+  const startTime = Date.now();
+
+  yield* Effect.log(`\nValidating PLL extracted data...`);
+  yield* Effect.log(`Output directory: ${pllDir}\n`);
+
+  const fileResults: (typeof FileValidationResult.Type)[] = [];
+  const crossRefs: (typeof CrossReferenceResult.Type)[] = [];
+
+  const { result: playerDetailsResult, data: playerDetails } =
+    yield* validateJsonArray<PlayerDetail>(
+      path.join(pllDir, "player-details.json"),
+      100,
+    );
+
+  if (playerDetails.length > 0) {
+    const requiredCheck = yield* validateRequiredFields(playerDetails, [
+      "slug",
+      "officialId",
+    ]);
+    const uniqueSlugCheck = yield* validateUniqueField(playerDetails, "slug");
+    const uniqueIdCheck = yield* validateUniqueField(
+      playerDetails,
+      "officialId",
+    );
+
+    const {
+      filePath: fp,
+      exists,
+      sizeBytes,
+      recordCount,
+      checks,
+    } = playerDetailsResult;
+    fileResults.push({
+      filePath: fp,
+      exists,
+      sizeBytes,
+      recordCount,
+      checks: [...checks, requiredCheck, uniqueSlugCheck, uniqueIdCheck],
+    });
+  } else {
+    fileResults.push(playerDetailsResult);
+  }
+
+  const { result: careerStatsResult, data: careerStats } =
+    yield* validateJsonArray<CareerStatsPlayer>(
+      path.join(pllDir, "career-stats.json"),
+      100,
+    );
+
+  if (careerStats.length > 0) {
+    const requiredCheck = yield* validateRequiredFields(careerStats, [
+      "name",
+      "stats",
+    ]);
+    const {
+      filePath: csFp,
+      exists: csExists,
+      sizeBytes: csSizeBytes,
+      recordCount: csRecordCount,
+      checks: csChecks,
+    } = careerStatsResult;
+    fileResults.push({
+      filePath: csFp,
+      exists: csExists,
+      sizeBytes: csSizeBytes,
+      recordCount: csRecordCount,
+      checks: [...csChecks, requiredCheck],
+    });
+
+    const pllPlayers = careerStats.filter((p) => p.inPlayerDetails);
+    const mllPlayers = careerStats.filter((p) => !p.inPlayerDetails);
+    yield* Effect.log(
+      `  Career stats breakdown: ${pllPlayers.length} PLL, ${mllPlayers.length} MLL/retired`,
+    );
+  } else {
+    fileResults.push(careerStatsResult);
+  }
+
+  const { result: eventDetailsResult, data: eventDetails } =
+    yield* validateJsonArray<EventDetailWrapper>(
+      path.join(pllDir, "event-details.json"),
+      50,
+    );
+
+  if (eventDetails.length > 0) {
+    const requiredCheck = yield* validateRequiredFields(eventDetails, [
+      "slug",
+      "year",
+      "detail",
+    ]);
+    const uniqueSlugCheck = yield* validateUniqueField(eventDetails, "slug");
+
+    const playLogCount = eventDetails.reduce(
+      (sum, e) => sum + (e.detail?.playLogs?.length ?? 0),
+      0,
+    );
+    yield* Effect.log(
+      `  Event details: ${eventDetails.length} events, ${playLogCount} total play logs`,
+    );
+
+    const {
+      filePath: edFp,
+      exists: edExists,
+      sizeBytes: edSizeBytes,
+      recordCount: edRecordCount,
+      checks: edChecks,
+    } = eventDetailsResult;
+    fileResults.push({
+      filePath: edFp,
+      exists: edExists,
+      sizeBytes: edSizeBytes,
+      recordCount: edRecordCount,
+      checks: [...edChecks, requiredCheck, uniqueSlugCheck],
+    });
+  } else {
+    fileResults.push(eventDetailsResult);
+  }
+
+  const { result: teamDetailsResult, data: teamDetails } =
+    yield* validateJsonArray<TeamDetailWrapper>(
+      path.join(pllDir, "team-details.json"),
+      20,
+    );
+
+  if (teamDetails.length > 0) {
+    const requiredCheck = yield* validateRequiredFields(teamDetails, [
+      "teamId",
+      "year",
+      "detail",
+    ]);
+    const {
+      filePath: tdFp,
+      exists: tdExists,
+      sizeBytes: tdSizeBytes,
+      recordCount: tdRecordCount,
+      checks: tdChecks,
+    } = teamDetailsResult;
+    fileResults.push({
+      filePath: tdFp,
+      exists: tdExists,
+      sizeBytes: tdSizeBytes,
+      recordCount: tdRecordCount,
+      checks: [...tdChecks, requiredCheck],
+    });
+  } else {
+    fileResults.push(teamDetailsResult);
+  }
+
+  const statLeadersPath = path.join(pllDir, "stat-leaders.json");
+  const statLeadersFileResult = yield* validateFileExists(statLeadersPath);
+
+  if (statLeadersFileResult.exists) {
+    const statLeadersData = yield* readJsonFile<StatLeadersData>(
+      statLeadersPath,
+    ).pipe(Effect.catchAll(() => Effect.succeed({} as StatLeadersData)));
+
+    const yearCount = Object.keys(statLeadersData).length;
+    const firstYearData = Object.values(statLeadersData)[0];
+    const statTypesPerYear = firstYearData
+      ? Object.keys(firstYearData).length
+      : 0;
+
+    const checkResult: typeof ValidationCheckResult.Type = {
+      checkName: "stat_leaders_structure",
+      passed: yearCount > 0,
+      issues:
+        yearCount === 0
+          ? [errorIssue("EMPTY_DATA", "No years found in stat leaders data")]
+          : [
+              infoIssue(
+                "DATA_STRUCTURE",
+                `${yearCount} years, ${statTypesPerYear} stat types per year`,
+              ),
+            ],
+      durationMs: 0,
+    };
+
+    yield* Effect.log(
+      `  Stat leaders: ${yearCount} years, ${statTypesPerYear} stat types each`,
+    );
+
+    const {
+      filePath: slFp,
+      exists: slExists,
+      sizeBytes: slSizeBytes,
+      checks: slChecks,
+    } = statLeadersFileResult;
+    fileResults.push({
+      filePath: slFp,
+      exists: slExists,
+      sizeBytes: slSizeBytes,
+      recordCount: yearCount,
+      checks: [...slChecks, checkResult],
+    });
+  } else {
+    fileResults.push(statLeadersFileResult);
+  }
+
+  for (const year of YEARS) {
+    const yearDir = path.join(pllDir, String(year));
+
+    const { result: playersResult } = yield* validateJsonArray(
+      path.join(yearDir, "players.json"),
+      10,
+    );
+    fileResults.push(playersResult);
+
+    const { result: teamsResult } = yield* validateJsonArray(
+      path.join(yearDir, "teams.json"),
+      6,
+    );
+    fileResults.push(teamsResult);
+  }
+
+  if (careerStats.length > 0 && playerDetails.length > 0) {
+    const careerStatsWithSlugs = careerStats.filter((p) => p.slug !== null);
+    const xref = yield* crossReference(
+      careerStatsWithSlugs,
+      playerDetails,
+      "slug",
+      "slug",
+      "career-stats.json",
+      "player-details.json",
+    );
+
+    crossRefs.push({
+      sourceFile: xref.sourceFile,
+      targetFile: xref.targetFile,
+      sourceField: xref.sourceField,
+      targetField: xref.targetField,
+      totalSourceRecords: xref.totalSourceRecords,
+      matchedRecords: xref.matchedRecords,
+      unmatchedRecords: xref.unmatchedRecords,
+      unmatchedSamples: xref.unmatchedSamples,
+    });
+  }
+
+  const report = buildReport("PLL", fileResults, crossRefs, startTime);
+  yield* printReport(report);
+
+  const reportPath = path.join(pllDir, "validation-report.json");
+  yield* Effect.tryPromise({
+    try: () => fs.writeFile(reportPath, JSON.stringify(report, null, 2)),
+    catch: (e) => new Error(`Failed to write report: ${String(e)}`),
+  });
+  yield* Effect.log(`Report saved to: ${reportPath}`);
+
+  return report;
+});
+
+await Effect.runPromise(
+  program.pipe(Effect.provide(ExtractConfigService.Default)),
+).catch(console.error);

--- a/packages/pipeline/src/validate/validate.schema.ts
+++ b/packages/pipeline/src/validate/validate.schema.ts
@@ -1,0 +1,116 @@
+import { Schema } from "effect";
+
+export type Severity = "error" | "warning" | "info";
+
+export class ValidationIssue extends Schema.Class<ValidationIssue>(
+  "ValidationIssue",
+)({
+  severity: Schema.Literal("error", "warning", "info"),
+  code: Schema.String,
+  message: Schema.String,
+  path: Schema.optional(Schema.String),
+  context: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  ),
+}) {}
+
+export class ValidationCheckResult extends Schema.Class<ValidationCheckResult>(
+  "ValidationCheckResult",
+)({
+  checkName: Schema.String,
+  passed: Schema.Boolean,
+  issues: Schema.Array(ValidationIssue),
+  durationMs: Schema.Number,
+}) {}
+
+export class FileValidationResult extends Schema.Class<FileValidationResult>(
+  "FileValidationResult",
+)({
+  filePath: Schema.String,
+  exists: Schema.Boolean,
+  sizeBytes: Schema.optional(Schema.Number),
+  recordCount: Schema.optional(Schema.Number),
+  checks: Schema.Array(ValidationCheckResult),
+}) {}
+
+export class CrossReferenceResult extends Schema.Class<CrossReferenceResult>(
+  "CrossReferenceResult",
+)({
+  sourceFile: Schema.String,
+  targetFile: Schema.String,
+  sourceField: Schema.String,
+  targetField: Schema.String,
+  totalSourceRecords: Schema.Number,
+  matchedRecords: Schema.Number,
+  unmatchedRecords: Schema.Number,
+  unmatchedSamples: Schema.optional(Schema.Array(Schema.Unknown)),
+}) {}
+
+export class DatasetStats extends Schema.Class<DatasetStats>("DatasetStats")({
+  totalRecords: Schema.Number,
+  uniqueValues: Schema.Record({ key: Schema.String, value: Schema.Number }),
+  nullCounts: Schema.Record({ key: Schema.String, value: Schema.Number }),
+  valueRanges: Schema.optional(
+    Schema.Record({
+      key: Schema.String,
+      value: Schema.Struct({
+        min: Schema.Unknown,
+        max: Schema.Unknown,
+      }),
+    }),
+  ),
+}) {}
+
+export class ValidationReport extends Schema.Class<ValidationReport>(
+  "ValidationReport",
+)({
+  source: Schema.String,
+  timestamp: Schema.String,
+  durationMs: Schema.Number,
+  summary: Schema.Struct({
+    totalChecks: Schema.Number,
+    passedChecks: Schema.Number,
+    failedChecks: Schema.Number,
+    errorCount: Schema.Number,
+    warningCount: Schema.Number,
+    infoCount: Schema.Number,
+  }),
+  files: Schema.Array(FileValidationResult),
+  crossReferences: Schema.optional(Schema.Array(CrossReferenceResult)),
+  overallValid: Schema.Boolean,
+}) {}
+
+export const createIssue = (
+  severity: Severity,
+  code: string,
+  message: string,
+  path?: string,
+  context?: Record<string, unknown>,
+): typeof ValidationIssue.Type => ({
+  severity,
+  code,
+  message,
+  path,
+  context,
+});
+
+export const errorIssue = (
+  code: string,
+  message: string,
+  path?: string,
+  context?: Record<string, unknown>,
+) => createIssue("error", code, message, path, context);
+
+export const warningIssue = (
+  code: string,
+  message: string,
+  path?: string,
+  context?: Record<string, unknown>,
+) => createIssue("warning", code, message, path, context);
+
+export const infoIssue = (
+  code: string,
+  message: string,
+  path?: string,
+  context?: Record<string, unknown>,
+) => createIssue("info", code, message, path, context);

--- a/packages/pipeline/src/validate/validate.service.ts
+++ b/packages/pipeline/src/validate/validate.service.ts
@@ -1,0 +1,455 @@
+import { Effect, Schema } from "effect";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+  type ValidationIssue,
+  type ValidationCheckResult,
+  type FileValidationResult,
+  type CrossReferenceResult,
+  type ValidationReport,
+  errorIssue,
+  warningIssue,
+  infoIssue,
+} from "./validate.schema";
+
+const readJsonFile = <T>(filePath: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const content = await fs.readFile(filePath, "utf-8");
+      return JSON.parse(content) as T;
+    },
+    catch: (e) => new Error(`Failed to read ${filePath}: ${String(e)}`),
+  });
+
+const getFileStats = (filePath: string) =>
+  Effect.tryPromise({
+    try: () => fs.stat(filePath),
+    catch: () => new Error("File not found"),
+  });
+
+const runCheck = (
+  checkName: string,
+  checkFn: () => Effect.Effect<(typeof ValidationIssue.Type)[], Error>,
+): Effect.Effect<typeof ValidationCheckResult.Type> =>
+  Effect.gen(function* () {
+    const start = Date.now();
+    const result = yield* checkFn().pipe(
+      Effect.catchAll((e) =>
+        Effect.succeed([errorIssue("CHECK_ERROR", e.message)]),
+      ),
+    );
+    const durationMs = Date.now() - start;
+    const hasErrors = result.some((i) => i.severity === "error");
+
+    return {
+      checkName,
+      passed: !hasErrors,
+      issues: result,
+      durationMs,
+    };
+  });
+
+export const validateFileExists = (
+  filePath: string,
+): Effect.Effect<typeof FileValidationResult.Type> =>
+  Effect.gen(function* () {
+    const statsResult = yield* getFileStats(filePath).pipe(
+      Effect.map((s) => ({ success: true as const, stats: s })),
+      Effect.catchAll(() =>
+        Effect.succeed({ success: false as const, stats: null }),
+      ),
+    );
+
+    if (!statsResult.success || !statsResult.stats) {
+      return {
+        filePath,
+        exists: false,
+        sizeBytes: undefined,
+        recordCount: undefined,
+        checks: [
+          {
+            checkName: "file_exists",
+            passed: false,
+            issues: [
+              errorIssue("FILE_NOT_FOUND", `File not found: ${filePath}`),
+            ],
+            durationMs: 0,
+          },
+        ],
+      };
+    }
+
+    return {
+      filePath,
+      exists: true,
+      sizeBytes: statsResult.stats.size,
+      recordCount: undefined,
+      checks: [
+        {
+          checkName: "file_exists",
+          passed: true,
+          issues: [],
+          durationMs: 0,
+        },
+      ],
+    };
+  });
+
+export const validateJsonArray = <T>(
+  filePath: string,
+  minRecords = 0,
+): Effect.Effect<{ result: typeof FileValidationResult.Type; data: T[] }> =>
+  Effect.gen(function* () {
+    const fileResult = yield* validateFileExists(filePath);
+
+    if (!fileResult.exists) {
+      return { result: fileResult, data: [] };
+    }
+
+    const parseCheck = yield* runCheck("json_parse", () =>
+      Effect.gen(function* () {
+        const data = yield* readJsonFile<unknown>(filePath);
+        const issues: (typeof ValidationIssue.Type)[] = [];
+
+        if (!Array.isArray(data)) {
+          issues.push(
+            errorIssue("NOT_ARRAY", `Expected array, got ${typeof data}`),
+          );
+          return issues;
+        }
+
+        if (data.length < minRecords) {
+          issues.push(
+            errorIssue(
+              "INSUFFICIENT_RECORDS",
+              `Expected at least ${minRecords} records, got ${data.length}`,
+            ),
+          );
+        }
+
+        return issues;
+      }),
+    );
+
+    const data = yield* readJsonFile<T[]>(filePath).pipe(
+      Effect.catchAll(() => Effect.succeed([] as T[])),
+    );
+
+    const { filePath: fp, exists, sizeBytes, checks } = fileResult;
+    return {
+      result: {
+        filePath: fp,
+        exists,
+        sizeBytes,
+        recordCount: Array.isArray(data) ? data.length : 0,
+        checks: [...checks, parseCheck],
+      },
+      data,
+    };
+  });
+
+export const validateSchema = <T, I>(
+  data: unknown[],
+  schema: Schema.Schema<T, I>,
+  sampleSize = 10,
+): Effect.Effect<typeof ValidationCheckResult.Type> =>
+  runCheck("schema_validation", () =>
+    Effect.gen(function* () {
+      const issues: (typeof ValidationIssue.Type)[] = [];
+      const samplesToCheck = data.slice(0, sampleSize);
+      let validCount = 0;
+      let invalidCount = 0;
+
+      for (let i = 0; i < samplesToCheck.length; i++) {
+        const result = yield* Schema.decodeUnknown(schema)(
+          samplesToCheck[i],
+        ).pipe(
+          Effect.map(() => true),
+          Effect.catchAll(() => Effect.succeed(false)),
+        );
+
+        if (result) {
+          validCount++;
+        } else {
+          invalidCount++;
+          if (invalidCount <= 3) {
+            issues.push(
+              warningIssue(
+                "SCHEMA_MISMATCH",
+                `Record at index ${i} failed schema validation`,
+                `[${i}]`,
+              ),
+            );
+          }
+        }
+      }
+
+      if (invalidCount > 0) {
+        issues.push(
+          infoIssue(
+            "SCHEMA_SUMMARY",
+            `Schema validation: ${validCount}/${samplesToCheck.length} passed (checked ${sampleSize} of ${data.length})`,
+          ),
+        );
+      }
+
+      return issues;
+    }),
+  );
+
+export const validateRequiredFields = <T extends object>(
+  data: T[],
+  requiredFields: (keyof T)[],
+): Effect.Effect<typeof ValidationCheckResult.Type> =>
+  runCheck("required_fields", () =>
+    Effect.succeed(
+      (() => {
+        const issues: (typeof ValidationIssue.Type)[] = [];
+        const missingCounts: Record<string, number> = {};
+
+        for (const record of data) {
+          for (const field of requiredFields) {
+            const value = record[field];
+            if (value === null || value === undefined || value === "") {
+              const key = String(field);
+              missingCounts[key] = (missingCounts[key] ?? 0) + 1;
+            }
+          }
+        }
+
+        for (const [field, count] of Object.entries(missingCounts)) {
+          const pct = ((count / data.length) * 100).toFixed(1);
+          if (count === data.length) {
+            issues.push(
+              errorIssue(
+                "FIELD_ALL_MISSING",
+                `Field "${field}" is missing in all ${count} records`,
+              ),
+            );
+          } else if (count > data.length * 0.5) {
+            issues.push(
+              warningIssue(
+                "FIELD_MOSTLY_MISSING",
+                `Field "${field}" is missing in ${count}/${data.length} records (${pct}%)`,
+              ),
+            );
+          } else {
+            issues.push(
+              infoIssue(
+                "FIELD_SOME_MISSING",
+                `Field "${field}" is missing in ${count}/${data.length} records (${pct}%)`,
+              ),
+            );
+          }
+        }
+
+        return issues;
+      })(),
+    ),
+  );
+
+export const validateUniqueField = <T extends object>(
+  data: T[],
+  field: keyof T,
+): Effect.Effect<typeof ValidationCheckResult.Type> =>
+  runCheck(`unique_${String(field)}`, () =>
+    Effect.succeed(
+      (() => {
+        const issues: (typeof ValidationIssue.Type)[] = [];
+        const seen = new Map<unknown, number>();
+        const duplicates: { value: unknown; count: number }[] = [];
+
+        for (const record of data) {
+          const value = record[field];
+          if (value !== null && value !== undefined) {
+            seen.set(value, (seen.get(value) ?? 0) + 1);
+          }
+        }
+
+        for (const [value, count] of seen.entries()) {
+          if (count > 1) {
+            duplicates.push({ value, count });
+          }
+        }
+
+        if (duplicates.length > 0) {
+          const sorted = duplicates.toSorted((a, b) => b.count - a.count);
+          const samples = sorted.slice(0, 5);
+
+          issues.push(
+            errorIssue(
+              "DUPLICATE_VALUES",
+              `Field "${String(field)}" has ${duplicates.length} duplicate values`,
+              String(field),
+              {
+                samples: samples.map((d) => `${String(d.value)} (${d.count}x)`),
+              },
+            ),
+          );
+        }
+
+        return issues;
+      })(),
+    ),
+  );
+
+export const crossReference = <S extends object, T extends object>(
+  sourceData: S[],
+  targetData: T[],
+  sourceField: keyof S,
+  targetField: keyof T,
+  sourceFile: string,
+  targetFile: string,
+): Effect.Effect<typeof CrossReferenceResult.Type> =>
+  Effect.succeed(
+    (() => {
+      const targetValues = new Set<unknown>();
+      for (const r of targetData) {
+        const v = r[targetField];
+        if (v !== null && v !== undefined) {
+          targetValues.add(v);
+        }
+      }
+
+      const unmatched: unknown[] = [];
+      let matched = 0;
+
+      for (const record of sourceData) {
+        const value = record[sourceField];
+        if (value !== null && value !== undefined) {
+          if (targetValues.has(value)) {
+            matched++;
+          } else if (unmatched.length < 10) {
+            unmatched.push(value);
+          }
+        }
+      }
+
+      return {
+        sourceFile,
+        targetFile,
+        sourceField: String(sourceField),
+        targetField: String(targetField),
+        totalSourceRecords: sourceData.length,
+        matchedRecords: matched,
+        unmatchedRecords: sourceData.length - matched,
+        unmatchedSamples: unmatched.length > 0 ? unmatched : undefined,
+      };
+    })(),
+  );
+
+export const buildReport = (
+  source: string,
+  files: (typeof FileValidationResult.Type)[],
+  crossRefs: (typeof CrossReferenceResult.Type)[],
+  startTime: number,
+): typeof ValidationReport.Type => {
+  let totalChecks = 0;
+  let passedChecks = 0;
+  let errorCount = 0;
+  let warningCount = 0;
+  let infoCount = 0;
+
+  for (const file of files) {
+    for (const check of file.checks) {
+      totalChecks++;
+      if (check.passed) passedChecks++;
+
+      for (const issue of check.issues) {
+        if (issue.severity === "error") errorCount++;
+        else if (issue.severity === "warning") warningCount++;
+        else infoCount++;
+      }
+    }
+  }
+
+  return {
+    source,
+    timestamp: new Date().toISOString(),
+    durationMs: Date.now() - startTime,
+    summary: {
+      totalChecks,
+      passedChecks,
+      failedChecks: totalChecks - passedChecks,
+      errorCount,
+      warningCount,
+      infoCount,
+    },
+    files,
+    crossReferences: crossRefs.length > 0 ? crossRefs : undefined,
+    overallValid: errorCount === 0,
+  };
+};
+
+export const printReport = (report: typeof ValidationReport.Type) =>
+  Effect.gen(function* () {
+    yield* Effect.log(`\n${"=".repeat(70)}`);
+    yield* Effect.log(`VALIDATION REPORT: ${report.source}`);
+    yield* Effect.log("=".repeat(70));
+    yield* Effect.log(`Timestamp: ${report.timestamp}`);
+    yield* Effect.log(`Duration: ${report.durationMs}ms`);
+    yield* Effect.log(`\nSUMMARY:`);
+    yield* Effect.log(
+      `  Checks: ${report.summary.passedChecks}/${report.summary.totalChecks} passed`,
+    );
+    yield* Effect.log(`  Errors: ${report.summary.errorCount}`);
+    yield* Effect.log(`  Warnings: ${report.summary.warningCount}`);
+    yield* Effect.log(`  Info: ${report.summary.infoCount}`);
+
+    yield* Effect.log(`\nFILES:`);
+    for (const file of report.files) {
+      const status = file.exists
+        ? file.checks.every((c) => c.passed)
+          ? "[OK]"
+          : "[!!]"
+        : "[--]";
+      const size = file.sizeBytes
+        ? `${(file.sizeBytes / 1024).toFixed(1)}KB`
+        : "N/A";
+      const count =
+        file.recordCount === undefined ? "" : `${file.recordCount} records`;
+      yield* Effect.log(
+        `  ${status} ${path.basename(file.filePath)} (${size}, ${count})`,
+      );
+
+      for (const check of file.checks) {
+        if (!check.passed || check.issues.length > 0) {
+          for (const issue of check.issues) {
+            const prefix =
+              issue.severity === "error"
+                ? "    [E]"
+                : issue.severity === "warning"
+                  ? "    [W]"
+                  : "    [i]";
+            yield* Effect.log(`${prefix} ${issue.message}`);
+          }
+        }
+      }
+    }
+
+    if (report.crossReferences && report.crossReferences.length > 0) {
+      yield* Effect.log(`\nCROSS-REFERENCES:`);
+      for (const xref of report.crossReferences) {
+        const matchPct = (
+          (xref.matchedRecords / xref.totalSourceRecords) *
+          100
+        ).toFixed(1);
+        const status = xref.unmatchedRecords === 0 ? "[OK]" : "[!!]";
+        yield* Effect.log(
+          `  ${status} ${path.basename(xref.sourceFile)}.${xref.sourceField} -> ${path.basename(xref.targetFile)}.${xref.targetField}`,
+        );
+        yield* Effect.log(
+          `       Matched: ${xref.matchedRecords}/${xref.totalSourceRecords} (${matchPct}%)`,
+        );
+        if (xref.unmatchedSamples && xref.unmatchedSamples.length > 0) {
+          yield* Effect.log(
+            `       Unmatched samples: ${xref.unmatchedSamples.slice(0, 5).join(", ")}`,
+          );
+        }
+      }
+    }
+
+    yield* Effect.log(`\n${"=".repeat(70)}`);
+    yield* Effect.log(`OVERALL: ${report.overallValid ? "VALID" : "INVALID"}`);
+    yield* Effect.log(`${"=".repeat(70)}\n`);
+  });


### PR DESCRIPTION
## Summary
Adds a comprehensive validation framework for verifying extracted PLL (Premier Lacrosse League) data integrity, including file existence checks, JSON parsing, required field validation, uniqueness constraints, and cross-reference validation between datasets.

## Changes
- Added reusable validation service with file, schema, and cross-reference validators (`src/validate/validate.service.ts`)
- Created validation schemas using Effect Schema for type-safe validation results (`src/validate/validate.schema.ts`)
- Implemented PLL-specific validation script that checks player details, career stats, events, teams, and stat leaders (`src/validate/validate-pll.ts`)
- Added validation documentation to AGENTS.md with usage examples and validation checks table
- Updated PLL_DATA_MODEL.md to document career stats extraction (1,170 players including MLL era)
- Added MLL (Major League Lacrosse) data discovery section explaining 801 MLL-only players vs 502 PLL players
- Validation generates JSON reports to `output/pll/validation-report.json` with error/warning/info categorization

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other

## Notes
The validation framework provides five key checks: `file_exists`, `json_parse`, `required_fields`, `unique_field`, and `cross_reference`. This enables automated validation of extracted data before database import, catching issues like missing files, duplicate IDs, or broken foreign key relationships early in the pipeline.

---
*Auto-generated by Claude. Feel free to edit.*