### PR TITLE
fix: remove gitignore from gitignore in scratchpad

### DIFF
--- a/scratchpad/.gitignore
+++ b/scratchpad/.gitignore
@@ -1,3 +1,4 @@
 *
 !package.json
+!.gitignore
 !tsconfig.json


### PR DESCRIPTION
## Summary
Fixes the scratchpad directory's `.gitignore` to properly track itself by adding an exception rule.

## Changes
- Added `!.gitignore` exception to `scratchpad/.gitignore` to ensure the gitignore file itself is tracked by git
- This prevents the gitignore file from being ignored by its own wildcard `*` rule

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other

## Notes
The scratchpad directory uses a whitelist approach with a wildcard ignore (`*`) followed by explicit exceptions. The `.gitignore` file itself needs to be excepted to be tracked in version control.

---
*Auto-generated by Claude. Feel free to edit.*