### PR TITLE
chore: add .ignore to give opencode access to the contents of scratchpad

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+!scratchpad
+!scratchpad/**


### PR DESCRIPTION
## Summary
Adds a `.ignore` file to explicitly whitelist the `scratchpad` directory, allowing OpenCode to access its contents for analysis and code intelligence.

## Changes
- Created `.ignore` file with negation patterns for `scratchpad` directory
- Whitelists both the directory itself and all its contents recursively

## Type
- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other

## Notes
The `.ignore` file uses negation patterns (`!`) to override default ignore rules, ensuring OpenCode tooling can properly index and access the scratchpad directory for development purposes.

---
*Auto-generated by Claude. Feel free to edit.*
