### PR TITLE
refactor(pipeline): update node utils to use effect version

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
   - [ ] blog
     - [ ] styling
   - [ ] tool plans
+- [ ] Tests
 
 - [ ] contributing docs site
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "oxfmt": "^0.19.0",
         "oxlint": "^1.36.0",
         "oxlint-tsgolint": "^0.10.0",
-        "turbo": "^2.7.2",
+        "turbo": "^2.7.3",
         "typescript": "^5.9.3",
         "vitest": "^4.0.16",
       },
@@ -32,7 +32,7 @@
       "name": "@laxdb/api",
       "dependencies": {
         "@effect-atom/atom-react": "^0.4.4",
-        "@effect/platform": "^0.94.0",
+        "@effect/platform": "0.94.1",
         "@effect/rpc": "^0.73.0",
         "@laxdb/core": "workspace:*",
       },
@@ -45,7 +45,7 @@
       "dependencies": {
         "@aws-sdk/client-sesv2": "^3.958.0",
         "@effect/experimental": "^0.58.0",
-        "@effect/platform": "^0.94.0",
+        "@effect/platform": "0.94.1",
         "@effect/platform-bun": "^0.87.0",
         "@effect/rpc": "^0.73.0",
         "@effect/sql": "^0.49.0",
@@ -148,6 +148,8 @@
     "packages/pipeline": {
       "name": "@laxdb/pipeline",
       "dependencies": {
+        "@effect/platform": "^0.94.1",
+        "@effect/platform-bun": "^0.87.0",
         "@laxdb/core": "*",
         "cheerio": "^1.1.2",
       },
@@ -456,7 +458,7 @@
 
     "@effect/language-service": ["@effect/language-service@0.62.5", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-vCMZkqbE8bQ4cmksrj2HLVhYXL6B0bs7uulALgVh6Hh46/V2WrcExgx6DTr0BE6nwBuecqbd4xWjEoPSwI8bPw=="],
 
-    "@effect/platform": ["@effect/platform@0.94.0", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.19.13" } }, "sha512-oIATd3M+RUe2q+bu0Qpgt4/qSbXBM9OEGBrRW7SvtwXGOWkCYkN+LfOPnmPrbMB7jYjpIb7808T1bONM1Nwgfg=="],
+    "@effect/platform": ["@effect/platform@0.94.1", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.19.14" } }, "sha512-SlL8OMTogHmMNnFLnPAHHo3ua1yrB1LNQOVQMiZsqYu9g3216xjr0gn5WoDgCxUyOdZcseegMjWJ7dhm/2vnfg=="],
 
     "@effect/platform-bun": ["@effect/platform-bun@0.87.0", "", { "dependencies": { "@effect/platform-node-shared": "^0.57.0", "multipasta": "^0.2.7" }, "peerDependencies": { "@effect/cluster": "^0.56.0", "@effect/platform": "^0.94.0", "@effect/rpc": "^0.73.0", "@effect/sql": "^0.49.0", "effect": "^3.19.13" } }, "sha512-O0WJXc5f4qTcdEXWQDb5JDT0b4qiSrrOovRiZ46O+c3ZdC6wkc7vuvmvI9L6gI3rNmDgPZtK+IkELH6P20dLXA=="],
 
@@ -2824,19 +2826,19 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
-    "turbo": ["turbo@2.7.2", "", { "optionalDependencies": { "turbo-darwin-64": "2.7.2", "turbo-darwin-arm64": "2.7.2", "turbo-linux-64": "2.7.2", "turbo-linux-arm64": "2.7.2", "turbo-windows-64": "2.7.2", "turbo-windows-arm64": "2.7.2" }, "bin": { "turbo": "bin/turbo" } }, "sha512-5JIA5aYBAJSAhrhbyag1ZuMSgUZnHtI+Sq3H8D3an4fL8PeF+L1yYvbEJg47akP1PFfATMf5ehkqFnxfkmuwZQ=="],
+    "turbo": ["turbo@2.7.3", "", { "optionalDependencies": { "turbo-darwin-64": "2.7.3", "turbo-darwin-arm64": "2.7.3", "turbo-linux-64": "2.7.3", "turbo-linux-arm64": "2.7.3", "turbo-windows-64": "2.7.3", "turbo-windows-arm64": "2.7.3" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+HjKlP4OfYk+qzvWNETA3cUO5UuK6b5MSc2UJOKyvBceKucQoQGb2g7HlC2H1GHdkfKrk4YF1VPvROkhVZDDLQ=="],
 
-    "turbo-darwin-64": ["turbo-darwin-64@2.7.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-dxY3X6ezcT5vm3coK6VGixbrhplbQMwgNsCsvZamS/+/6JiebqW9DKt4NwpgYXhDY2HdH00I7FWs3wkVuan4rA=="],
+    "turbo-darwin-64": ["turbo-darwin-64@2.7.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-aZHhvRiRHXbJw1EcEAq4aws1hsVVUZ9DPuSFaq9VVFAKCup7niIEwc22glxb7240yYEr1vLafdQ2U294Vcwz+w=="],
 
-    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.7.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1bXmuwPLqNFt3mzrtYcVx1sdJ8UYb124Bf48nIgcpMCGZy3kDhgxNv1503kmuK/37OGOZbsWSQFU4I08feIuSg=="],
+    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.7.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CkVrHSq+Bnhl9sX2LQgqQYVfLTWC2gvI74C4758OmU0djfrssDKU9d4YQF0AYXXhIIRZipSXfxClQziIMD+EAg=="],
 
-    "turbo-linux-64": ["turbo-linux-64@2.7.2", "", { "os": "linux", "cpu": "x64" }, "sha512-kP+TiiMaiPugbRlv57VGLfcjFNsFbo8H64wMBCPV2270Or2TpDCBULMzZrvEsvWFjT3pBFvToYbdp8/Kw0jAQg=="],
+    "turbo-linux-64": ["turbo-linux-64@2.7.3", "", { "os": "linux", "cpu": "x64" }, "sha512-GqDsCNnzzr89kMaLGpRALyigUklzgxIrSy2pHZVXyifgczvYPnLglex78Aj3T2gu+T3trPPH2iJ+pWucVOCC2Q=="],
 
-    "turbo-linux-arm64": ["turbo-linux-arm64@2.7.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-VDJwQ0+8zjAfbyY6boNaWfP6RIez4ypKHxwkuB6SrWbOSk+vxTyW5/hEjytTwK8w/TsbKVcMDyvpora8tEsRFw=="],
+    "turbo-linux-arm64": ["turbo-linux-arm64@2.7.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-NdCDTfIcIo3dWjsiaAHlxu5gW61Ed/8maah1IAF/9E3EtX0aAHNiBMbuYLZaR4vRJ7BeVkYB6xKWRtdFLZ0y3g=="],
 
-    "turbo-windows-64": ["turbo-windows-64@2.7.2", "", { "os": "win32", "cpu": "x64" }, "sha512-rPjqQXVnI6A6oxgzNEE8DNb6Vdj2Wwyhfv3oDc+YM3U9P7CAcBIlKv/868mKl4vsBtz4ouWpTQNXG8vljgJO+w=="],
+    "turbo-windows-64": ["turbo-windows-64@2.7.3", "", { "os": "win32", "cpu": "x64" }, "sha512-7bVvO987daXGSJVYBoG8R4Q+csT1pKIgLJYZevXRQ0Hqw0Vv4mKme/TOjYXs9Qb1xMKh51Tb3bXKDbd8/4G08g=="],
 
-    "turbo-windows-arm64": ["turbo-windows-arm64@2.7.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-tcnHvBhO515OheIFWdxA+qUvZzNqqcHbLVFc1+n+TJ1rrp8prYicQtbtmsiKgMvr/54jb9jOabU62URAobnB7g=="],
+    "turbo-windows-arm64": ["turbo-windows-arm64@2.7.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-nTodweTbPmkvwMu/a55XvjMsPtuyUSC+sV7f/SR57K36rB2I0YG21qNETN+00LOTUW9B3omd8XkiXJkt4kx/cw=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
@@ -3037,8 +3039,6 @@
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
-
-    "@effect-atom/atom/@effect/platform": ["@effect/platform@0.93.8", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.19.12" } }, "sha512-xTEy6fyTy4ijmFC3afKgtvYtn/JyPoIov4ZSUWJZUv3VeOcUPNGrrqG6IJlWkXs3NhvSywKv7wc1kw3epCQVZw=="],
 
     "@effect/platform-node-shared/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "oxfmt": "^0.19.0",
     "oxlint": "^1.36.0",
     "oxlint-tsgolint": "^0.10.0",
-    "turbo": "^2.7.2",
+    "turbo": "^2.7.3",
     "typescript": "^5.9.3",
     "vitest": "^4.0.16"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@effect-atom/atom-react": "^0.4.4",
-    "@effect/platform": "^0.94.0",
+    "@effect/platform": "0.94.1",
     "@effect/rpc": "^0.73.0",
     "@laxdb/core": "workspace:*"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aws-sdk/client-sesv2": "^3.958.0",
     "@effect/experimental": "^0.58.0",
-    "@effect/platform": "^0.94.0",
+    "@effect/platform": "0.94.1",
     "@effect/platform-bun": "^0.87.0",
     "@effect/rpc": "^0.73.0",
     "@effect/sql": "^0.49.0",

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -5,6 +5,19 @@ import {
   DatabaseError,
   ValidationError,
 } from "./error";
+import { FileSystem } from "@effect/platform";
+
+export const readJsonFile = <T>(filePath: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const content = yield* fs.readFileString(filePath, "utf-8");
+    const parsed: unknown = JSON.parse(content);
+    return parsed as T;
+  }).pipe(
+    Effect.catchAll((e) =>
+      Effect.fail(new Error(`Failed to read ${filePath}: ${String(e)}`)),
+    ),
+  );
 
 export const decodeArguments = <A, I, R>(
   schema: Schema.Schema<A, I, R>,

--- a/packages/pipeline/TODO.md
+++ b/packages/pipeline/TODO.md
@@ -3,8 +3,11 @@
 ## Next
 
 - [ ] clean up current 
-  - [ ] Node usages should be effect.
+  - [x] Node fs usages should be effect.
+  - [ ] shared utils move to core.
+  - [ ] Same thing with path?
   - [ ] Before all - remove try catches
+  - [ ] Fix change provide calls
 - [ ] Add other endpoints from PLL
 - [ ] Game events -> structured data
 - [ ] Integration test issue

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -14,6 +14,8 @@
     "fix": "bun run lint && bun run format"
   },
   "dependencies": {
+    "@effect/platform": "^0.94.1",
+    "@effect/platform-bun": "^0.87.0",
     "@laxdb/core": "*",
     "cheerio": "^1.1.2"
   },

--- a/packages/pipeline/src/extract/extract.config.ts
+++ b/packages/pipeline/src/extract/extract.config.ts
@@ -1,5 +1,6 @@
+import { Path } from "@effect/platform";
+import { BunContext } from "@effect/platform-bun";
 import { Effect, Config } from "effect";
-import * as path from "node:path";
 
 export interface ExtractConfig {
   readonly outputDir: string;
@@ -8,14 +9,14 @@ export interface ExtractConfig {
   readonly delayBetweenBatchesMs: number;
 }
 
-const DEFAULT_OUTPUT_DIR = path.join(process.cwd(), "output");
-
 export class ExtractConfigService extends Effect.Service<ExtractConfigService>()(
   "ExtractConfigService",
   {
     effect: Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const defaultOutputDir = path.join(process.cwd(), "output");
       const outputDir = yield* Config.string("EXTRACT_OUTPUT_DIR").pipe(
-        Config.withDefault(DEFAULT_OUTPUT_DIR),
+        Config.withDefault(defaultOutputDir),
       );
       const concurrency = yield* Config.number("EXTRACT_CONCURRENCY").pipe(
         Config.withDefault(5),
@@ -34,5 +35,6 @@ export class ExtractConfigService extends Effect.Service<ExtractConfigService>()
         delayBetweenBatchesMs,
       } satisfies ExtractConfig;
     }),
+    dependencies: [BunContext.layer],
   },
 ) {}

--- a/packages/pipeline/src/validate/data-anomaly.test.ts
+++ b/packages/pipeline/src/validate/data-anomaly.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, beforeAll } from "vitest";
-import { Schema } from "effect";
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
+import { FileSystem, Path } from "@effect/platform";
+import { BunContext } from "@effect/platform-bun";
+import { describe, it, expect, beforeAll } from "@effect/vitest";
+import { Effect, Schema, Ref } from "effect";
 
-const OUTPUT_DIR = path.join(__dirname, "../../output/pll");
+const TestLayer = BunContext.layer;
 
 const PlayerDetailSchema = Schema.Struct({
   slug: Schema.String,
@@ -97,11 +97,6 @@ const YearTeamSchema = Schema.Struct({
 });
 type YearTeam = Schema.Schema.Type<typeof YearTeamSchema>;
 
-let playerDetails: PlayerDetail[] = [];
-let careerStats: CareerStatsPlayer[] = [];
-let yearPlayers: Record<string, YearPlayer[]> = {};
-let yearTeams: Record<string, YearTeam[]> = {};
-
 const YEARS = ["2019", "2020", "2021", "2022", "2023", "2024", "2025"];
 const VALID_TEAM_IDS = new Set([
   "ARC",
@@ -138,437 +133,522 @@ const parseJsonArray = <A, I>(
   }
 };
 
+const playerDetailsRef = Ref.unsafeMake<PlayerDetail[]>([]);
+const careerStatsRef = Ref.unsafeMake<CareerStatsPlayer[]>([]);
+const yearPlayersRef = Ref.unsafeMake<Record<string, YearPlayer[]>>({});
+const yearTeamsRef = Ref.unsafeMake<Record<string, YearTeam[]>>({});
+
+const loadTestData = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const outputDir = pathService.join(process.cwd(), "output", "pll");
+
+  const playerDetails = yield* fs
+    .readFileString(pathService.join(outputDir, "player-details.json"))
+    .pipe(
+      Effect.map((content) => parseJsonArray(content, PlayerDetailSchema)),
+      Effect.catchAll(() => Effect.succeed([] as PlayerDetail[])),
+    );
+  yield* Ref.set(playerDetailsRef, playerDetails);
+
+  const careerStats = yield* fs
+    .readFileString(pathService.join(outputDir, "career-stats.json"))
+    .pipe(
+      Effect.map((content) => parseJsonArray(content, CareerStatsPlayerSchema)),
+      Effect.catchAll(() => Effect.succeed([] as CareerStatsPlayer[])),
+    );
+  yield* Ref.set(careerStatsRef, careerStats);
+
+  const yearPlayers: Record<string, YearPlayer[]> = {};
+  const yearTeams: Record<string, YearTeam[]> = {};
+
+  for (const year of YEARS) {
+    yearPlayers[year] = yield* fs
+      .readFileString(pathService.join(outputDir, year, "players.json"))
+      .pipe(
+        Effect.map((content) => parseJsonArray(content, YearPlayerSchema)),
+        Effect.catchAll(() => Effect.succeed([] as YearPlayer[])),
+      );
+
+    yearTeams[year] = yield* fs
+      .readFileString(pathService.join(outputDir, year, "teams.json"))
+      .pipe(
+        Effect.map((content) => parseJsonArray(content, YearTeamSchema)),
+        Effect.catchAll(() => Effect.succeed([] as YearTeam[])),
+      );
+  }
+
+  yield* Ref.set(yearPlayersRef, yearPlayers);
+  yield* Ref.set(yearTeamsRef, yearTeams);
+});
+
 beforeAll(async () => {
-  try {
-    const pdContent = await fs.readFile(
-      path.join(OUTPUT_DIR, "player-details.json"),
-      "utf-8",
-    );
-    playerDetails = parseJsonArray(pdContent, PlayerDetailSchema);
-  } catch {
-    playerDetails = [];
-  }
-
-  try {
-    const csContent = await fs.readFile(
-      path.join(OUTPUT_DIR, "career-stats.json"),
-      "utf-8",
-    );
-    careerStats = parseJsonArray(csContent, CareerStatsPlayerSchema);
-  } catch {
-    careerStats = [];
-  }
-
-  await Promise.all(
-    YEARS.map(async (year) => {
-      try {
-        const content = await fs.readFile(
-          path.join(OUTPUT_DIR, year, "players.json"),
-          "utf-8",
-        );
-        yearPlayers[year] = parseJsonArray(content, YearPlayerSchema);
-      } catch {
-        yearPlayers[year] = [];
-      }
-
-      try {
-        const content = await fs.readFile(
-          path.join(OUTPUT_DIR, year, "teams.json"),
-          "utf-8",
-        );
-        yearTeams[year] = parseJsonArray(content, YearTeamSchema);
-      } catch {
-        yearTeams[year] = [];
-      }
-    }),
-  );
+  await Effect.runPromise(loadTestData.pipe(Effect.provide(TestLayer)));
 });
 
 describe("Data Anomaly Detection", () => {
   describe("Player Details - Stat Consistency", () => {
-    it("points should equal goals + assists for all players", () => {
-      const violations: string[] = [];
+    it.effect("points should equal goals + assists for all players", () =>
+      Effect.gen(function* () {
+        const playerDetails = yield* Ref.get(playerDetailsRef);
+        const violations: string[] = [];
 
-      for (const player of playerDetails) {
-        if (!player.careerStats) continue;
-        const { goals, assists, points } = player.careerStats;
-        if (points !== goals + assists) {
-          violations.push(
-            `${player.firstName} ${player.lastName}: points(${points}) != goals(${goals}) + assists(${assists})`,
-          );
-        }
-      }
-
-      expect(violations).toHaveLength(0);
-    });
-
-    it("shot percentage should be calculable from goals and shots", () => {
-      const violations: string[] = [];
-
-      for (const player of playerDetails) {
-        if (!player.careerStats) continue;
-        const { goals, shots, shotPct } = player.careerStats;
-        if (shots === 0) continue;
-
-        const calculatedPct = (goals / shots) * 100;
-        const diff = Math.abs(calculatedPct - shotPct);
-
-        if (diff > 1) {
-          violations.push(
-            `${player.firstName} ${player.lastName}: shotPct(${shotPct}) differs from calculated(${calculatedPct.toFixed(1)}) by ${diff.toFixed(1)}%`,
-          );
-        }
-      }
-
-      if (violations.length > 0) {
-        console.warn(`Shot percentage anomalies found: ${violations.length}`);
-      }
-      expect(violations.length).toBeLessThan(10);
-    });
-
-    it("goals should never exceed shots", () => {
-      const violations: string[] = [];
-
-      for (const player of playerDetails) {
-        if (!player.careerStats) continue;
-        const { goals, shots } = player.careerStats;
-
-        if (goals > shots) {
-          violations.push(
-            `${player.firstName} ${player.lastName}: goals(${goals}) > shots(${shots})`,
-          );
-        }
-      }
-
-      expect(violations).toHaveLength(0);
-    });
-
-    it("save percentage should be between 0 and 100", () => {
-      const violations: string[] = [];
-
-      for (const player of playerDetails) {
-        if (!player.careerStats) continue;
-        const { savePct, saves } = player.careerStats;
-        if (saves === 0) continue;
-
-        if (savePct < 0 || savePct > 100) {
-          violations.push(
-            `${player.firstName} ${player.lastName}: savePct(${savePct}) out of range`,
-          );
-        }
-      }
-
-      expect(violations).toHaveLength(0);
-    });
-
-    it("faceoff percentage should be calculable from wins and total", () => {
-      const violations: string[] = [];
-
-      for (const player of playerDetails) {
-        if (!player.careerStats) continue;
-        const { faceoffsWon, faceoffs, faceoffPct } = player.careerStats;
-        if (faceoffs === 0) continue;
-
-        const calculatedPct = (faceoffsWon / faceoffs) * 100;
-        const diff = Math.abs(calculatedPct - faceoffPct);
-
-        if (diff > 1) {
-          violations.push(
-            `${player.firstName} ${player.lastName}: faceoffPct(${faceoffPct}) differs from calculated(${calculatedPct.toFixed(1)})`,
-          );
-        }
-      }
-
-      if (violations.length > 0) {
-        console.warn(`Faceoff percentage anomalies: ${violations.length}`);
-      }
-      expect(violations.length).toBeLessThan(5);
-    });
-  });
-
-  describe("Career Stats - MLL/PLL Classification", () => {
-    it("PLL players with pre-2019 years should also have 2019+ years (bridge players)", () => {
-      const violations: string[] = [];
-
-      for (const player of careerStats) {
-        if (player.likelySource !== "pll") continue;
-        if (!player.allYears) continue;
-
-        const hasPrePLLYear = player.allYears.some((y) => y < 2019);
-        const hasPLLYear = player.allYears.some((y) => y >= 2019);
-
-        if (hasPrePLLYear && !hasPLLYear) {
-          violations.push(
-            `${player.name}: marked as PLL but no years >= 2019: ${player.allYears.join(", ")}`,
-          );
-        }
-      }
-
-      expect(violations).toHaveLength(0);
-    });
-
-    it("bridge players (MLL to PLL) should be identified", () => {
-      const bridgePlayers = careerStats.filter((p) => {
-        if (p.likelySource !== "pll" || !p.allYears) return false;
-        const hasPrePLL = p.allYears.some((y) => y < 2019);
-        const hasPLL = p.allYears.some((y) => y >= 2019);
-        return hasPrePLL && hasPLL;
-      });
-
-      expect(bridgePlayers.length).toBeGreaterThan(100);
-      console.log(`Found ${bridgePlayers.length} bridge players (MLL → PLL)`);
-    });
-
-    it("MLL players should have years < 2019 (mostly)", () => {
-      const mllPlayers = careerStats.filter(
-        (p) => p.likelySource === "mll_or_retired",
-      );
-      const mllWithOnlyPostPLL = mllPlayers.filter((p) => {
-        if (!p.allYears) return false;
-        return p.allYears.every((y) => y >= 2019);
-      });
-
-      expect(mllWithOnlyPostPLL.length).toBeLessThan(mllPlayers.length * 0.1);
-    });
-
-    it("inPlayerDetails flag should be accurate", () => {
-      const playerDetailSlugs = new Set(playerDetails.map((p) => p.slug));
-      const violations: string[] = [];
-
-      for (const player of careerStats) {
-        if (!player.slug) continue;
-
-        const inDetails = playerDetailSlugs.has(player.slug);
-        if (inDetails !== player.inPlayerDetails) {
-          violations.push(
-            `${player.name}: inPlayerDetails(${player.inPlayerDetails}) but ${inDetails ? "found" : "not found"} in player-details.json`,
-          );
-        }
-      }
-
-      expect(violations).toHaveLength(0);
-    });
-  });
-
-  describe("Year Players - Team References", () => {
-    it("all player team references should be valid team IDs", () => {
-      const violations: string[] = [];
-
-      for (const year of YEARS) {
-        const players = yearPlayers[year] ?? [];
-
-        for (const player of players) {
-          for (const team of player.allTeams) {
-            if (!VALID_TEAM_IDS.has(team.officialId)) {
-              violations.push(
-                `${year} ${player.firstName} ${player.lastName}: invalid team ID "${team.officialId}"`,
-              );
-            }
-          }
-        }
-      }
-
-      expect(violations).toHaveLength(0);
-    });
-
-    it("all positions should be valid position codes", () => {
-      const violations: string[] = [];
-
-      for (const year of YEARS) {
-        const players = yearPlayers[year] ?? [];
-
-        for (const player of players) {
-          for (const team of player.allTeams) {
-            if (!VALID_POSITIONS.has(team.position)) {
-              violations.push(
-                `${year} ${player.firstName} ${player.lastName}: invalid position "${team.position}"`,
-              );
-            }
-          }
-        }
-      }
-
-      expect(violations).toHaveLength(0);
-    });
-
-    it("player officialId should be consistent across years", () => {
-      const playerIdsBySlug = new Map<string, Set<string>>();
-
-      for (const year of YEARS) {
-        const players = yearPlayers[year] ?? [];
-
-        for (const player of players) {
-          if (!player.slug) continue;
-
-          if (!playerIdsBySlug.has(player.slug)) {
-            playerIdsBySlug.set(player.slug, new Set());
-          }
-          playerIdsBySlug.get(player.slug)?.add(player.officialId);
-        }
-      }
-
-      const violations: string[] = [];
-      for (const [slug, ids] of playerIdsBySlug) {
-        if (ids.size > 1) {
-          violations.push(
-            `${slug}: multiple officialIds: ${[...ids].join(", ")}`,
-          );
-        }
-      }
-
-      expect(violations).toHaveLength(0);
-    });
-  });
-
-  describe("Year Teams - Record Consistency", () => {
-    it("team wins + losses should equal games played (approximately)", () => {
-      const violations: string[] = [];
-
-      for (const year of YEARS) {
-        const teams = yearTeams[year] ?? [];
-
-        for (const team of teams) {
-          if (!team.stats) continue;
-          const { gamesPlayed } = team.stats;
-          const totalGames = team.teamWins + team.teamLosses;
-
-          if (gamesPlayed !== totalGames) {
+        for (const player of playerDetails) {
+          if (!player.careerStats) continue;
+          const { goals, assists, points } = player.careerStats;
+          if (points !== goals + assists) {
             violations.push(
-              `${year} ${team.fullName}: gamesPlayed(${gamesPlayed}) != wins(${team.teamWins}) + losses(${team.teamLosses})`,
+              `${player.firstName} ${player.lastName}: points(${points}) != goals(${goals}) + assists(${assists})`,
             );
           }
         }
-      }
 
-      if (violations.length > 0) {
-        console.warn(
-          `Team record anomalies: ${violations.slice(0, 5).join("\n")}`,
-        );
-      }
-      expect(violations.length).toBeLessThan(20);
-    });
+        expect(violations).toHaveLength(0);
+      }),
+    );
 
-    it("team goals should never exceed shots", () => {
-      const violations: string[] = [];
+    it.effect("shot percentage should be calculable from goals and shots", () =>
+      Effect.gen(function* () {
+        const playerDetails = yield* Ref.get(playerDetailsRef);
+        const violations: string[] = [];
 
-      for (const year of YEARS) {
-        const teams = yearTeams[year] ?? [];
+        for (const player of playerDetails) {
+          if (!player.careerStats) continue;
+          const { goals, shots, shotPct } = player.careerStats;
+          if (shots === 0) continue;
 
-        for (const team of teams) {
-          if (!team.stats) continue;
-          const { goals, shots } = team.stats;
+          const calculatedPct = (goals / shots) * 100;
+          const diff = Math.abs(calculatedPct - shotPct);
+
+          if (diff > 1) {
+            violations.push(
+              `${player.firstName} ${player.lastName}: shotPct(${shotPct}) differs from calculated(${calculatedPct.toFixed(1)}) by ${diff.toFixed(1)}%`,
+            );
+          }
+        }
+
+        if (violations.length > 0) {
+          console.warn(`Shot percentage anomalies found: ${violations.length}`);
+        }
+        expect(violations.length).toBeLessThan(10);
+      }),
+    );
+
+    it.effect("goals should never exceed shots", () =>
+      Effect.gen(function* () {
+        const playerDetails = yield* Ref.get(playerDetailsRef);
+        const violations: string[] = [];
+
+        for (const player of playerDetails) {
+          if (!player.careerStats) continue;
+          const { goals, shots } = player.careerStats;
 
           if (goals > shots) {
             violations.push(
-              `${year} ${team.fullName}: goals(${goals}) > shots(${shots})`,
+              `${player.firstName} ${player.lastName}: goals(${goals}) > shots(${shots})`,
             );
           }
         }
-      }
 
-      expect(violations).toHaveLength(0);
-    });
+        expect(violations).toHaveLength(0);
+      }),
+    );
+
+    it.effect("save percentage should be between 0 and 100", () =>
+      Effect.gen(function* () {
+        const playerDetails = yield* Ref.get(playerDetailsRef);
+        const violations: string[] = [];
+
+        for (const player of playerDetails) {
+          if (!player.careerStats) continue;
+          const { savePct, saves } = player.careerStats;
+          if (saves === 0) continue;
+
+          if (savePct < 0 || savePct > 100) {
+            violations.push(
+              `${player.firstName} ${player.lastName}: savePct(${savePct}) out of range`,
+            );
+          }
+        }
+
+        expect(violations).toHaveLength(0);
+      }),
+    );
+
+    it.effect(
+      "faceoff percentage should be calculable from wins and total",
+      () =>
+        Effect.gen(function* () {
+          const playerDetails = yield* Ref.get(playerDetailsRef);
+          const violations: string[] = [];
+
+          for (const player of playerDetails) {
+            if (!player.careerStats) continue;
+            const { faceoffsWon, faceoffs, faceoffPct } = player.careerStats;
+            if (faceoffs === 0) continue;
+
+            const calculatedPct = (faceoffsWon / faceoffs) * 100;
+            const diff = Math.abs(calculatedPct - faceoffPct);
+
+            if (diff > 1) {
+              violations.push(
+                `${player.firstName} ${player.lastName}: faceoffPct(${faceoffPct}) differs from calculated(${calculatedPct.toFixed(1)})`,
+              );
+            }
+          }
+
+          if (violations.length > 0) {
+            console.warn(`Faceoff percentage anomalies: ${violations.length}`);
+          }
+          expect(violations.length).toBeLessThan(5);
+        }),
+    );
+  });
+
+  describe("Career Stats - MLL/PLL Classification", () => {
+    it.effect(
+      "PLL players with pre-2019 years should also have 2019+ years (bridge players)",
+      () =>
+        Effect.gen(function* () {
+          const careerStats = yield* Ref.get(careerStatsRef);
+          const violations: string[] = [];
+
+          for (const player of careerStats) {
+            if (player.likelySource !== "pll") continue;
+            if (!player.allYears) continue;
+
+            const hasPrePLLYear = player.allYears.some((y) => y < 2019);
+            const hasPLLYear = player.allYears.some((y) => y >= 2019);
+
+            if (hasPrePLLYear && !hasPLLYear) {
+              violations.push(
+                `${player.name}: marked as PLL but no years >= 2019: ${player.allYears.join(", ")}`,
+              );
+            }
+          }
+
+          expect(violations).toHaveLength(0);
+        }),
+    );
+
+    it.effect("bridge players (MLL to PLL) should be identified", () =>
+      Effect.gen(function* () {
+        const careerStats = yield* Ref.get(careerStatsRef);
+        const bridgePlayers = careerStats.filter((p) => {
+          if (p.likelySource !== "pll" || !p.allYears) return false;
+          const hasPrePLL = p.allYears.some((y) => y < 2019);
+          const hasPLL = p.allYears.some((y) => y >= 2019);
+          return hasPrePLL && hasPLL;
+        });
+
+        expect(bridgePlayers.length).toBeGreaterThan(100);
+        console.log(`Found ${bridgePlayers.length} bridge players (MLL → PLL)`);
+      }),
+    );
+
+    it.effect("MLL players should have years < 2019 (mostly)", () =>
+      Effect.gen(function* () {
+        const careerStats = yield* Ref.get(careerStatsRef);
+        const mllPlayers = careerStats.filter(
+          (p) => p.likelySource === "mll_or_retired",
+        );
+        const mllWithOnlyPostPLL = mllPlayers.filter((p) => {
+          if (!p.allYears) return false;
+          return p.allYears.every((y) => y >= 2019);
+        });
+
+        expect(mllWithOnlyPostPLL.length).toBeLessThan(mllPlayers.length * 0.1);
+      }),
+    );
+
+    it.effect("inPlayerDetails flag should be accurate", () =>
+      Effect.gen(function* () {
+        const playerDetails = yield* Ref.get(playerDetailsRef);
+        const careerStats = yield* Ref.get(careerStatsRef);
+        const playerDetailSlugs = new Set(playerDetails.map((p) => p.slug));
+        const violations: string[] = [];
+
+        for (const player of careerStats) {
+          if (!player.slug) continue;
+
+          const inDetails = playerDetailSlugs.has(player.slug);
+          if (inDetails !== player.inPlayerDetails) {
+            violations.push(
+              `${player.name}: inPlayerDetails(${player.inPlayerDetails}) but ${inDetails ? "found" : "not found"} in player-details.json`,
+            );
+          }
+        }
+
+        expect(violations).toHaveLength(0);
+      }),
+    );
+  });
+
+  describe("Year Players - Team References", () => {
+    it.effect("all player team references should be valid team IDs", () =>
+      Effect.gen(function* () {
+        const yearPlayers = yield* Ref.get(yearPlayersRef);
+        const violations: string[] = [];
+
+        for (const year of YEARS) {
+          const players = yearPlayers[year] ?? [];
+
+          for (const player of players) {
+            for (const team of player.allTeams) {
+              if (!VALID_TEAM_IDS.has(team.officialId)) {
+                violations.push(
+                  `${year} ${player.firstName} ${player.lastName}: invalid team ID "${team.officialId}"`,
+                );
+              }
+            }
+          }
+        }
+
+        expect(violations).toHaveLength(0);
+      }),
+    );
+
+    it.effect("all positions should be valid position codes", () =>
+      Effect.gen(function* () {
+        const yearPlayers = yield* Ref.get(yearPlayersRef);
+        const violations: string[] = [];
+
+        for (const year of YEARS) {
+          const players = yearPlayers[year] ?? [];
+
+          for (const player of players) {
+            for (const team of player.allTeams) {
+              if (!VALID_POSITIONS.has(team.position)) {
+                violations.push(
+                  `${year} ${player.firstName} ${player.lastName}: invalid position "${team.position}"`,
+                );
+              }
+            }
+          }
+        }
+
+        expect(violations).toHaveLength(0);
+      }),
+    );
+
+    it.effect("player officialId should be consistent across years", () =>
+      Effect.gen(function* () {
+        const yearPlayers = yield* Ref.get(yearPlayersRef);
+        const playerIdsBySlug = new Map<string, Set<string>>();
+
+        for (const year of YEARS) {
+          const players = yearPlayers[year] ?? [];
+
+          for (const player of players) {
+            if (!player.slug) continue;
+
+            if (!playerIdsBySlug.has(player.slug)) {
+              playerIdsBySlug.set(player.slug, new Set());
+            }
+            playerIdsBySlug.get(player.slug)?.add(player.officialId);
+          }
+        }
+
+        const violations: string[] = [];
+        for (const [slug, ids] of playerIdsBySlug) {
+          if (ids.size > 1) {
+            violations.push(
+              `${slug}: multiple officialIds: ${[...ids].join(", ")}`,
+            );
+          }
+        }
+
+        expect(violations).toHaveLength(0);
+      }),
+    );
+  });
+
+  describe("Year Teams - Record Consistency", () => {
+    it.effect(
+      "team wins + losses should equal games played (approximately)",
+      () =>
+        Effect.gen(function* () {
+          const yearTeams = yield* Ref.get(yearTeamsRef);
+          const violations: string[] = [];
+
+          for (const year of YEARS) {
+            const teams = yearTeams[year] ?? [];
+
+            for (const team of teams) {
+              if (!team.stats) continue;
+              const { gamesPlayed } = team.stats;
+              const totalGames = team.teamWins + team.teamLosses;
+
+              if (gamesPlayed !== totalGames) {
+                violations.push(
+                  `${year} ${team.fullName}: gamesPlayed(${gamesPlayed}) != wins(${team.teamWins}) + losses(${team.teamLosses})`,
+                );
+              }
+            }
+          }
+
+          if (violations.length > 0) {
+            console.warn(
+              `Team record anomalies: ${violations.slice(0, 5).join("\n")}`,
+            );
+          }
+          expect(violations.length).toBeLessThan(20);
+        }),
+    );
+
+    it.effect("team goals should never exceed shots", () =>
+      Effect.gen(function* () {
+        const yearTeams = yield* Ref.get(yearTeamsRef);
+        const violations: string[] = [];
+
+        for (const year of YEARS) {
+          const teams = yearTeams[year] ?? [];
+
+          for (const team of teams) {
+            if (!team.stats) continue;
+            const { goals, shots } = team.stats;
+
+            if (goals > shots) {
+              violations.push(
+                `${year} ${team.fullName}: goals(${goals}) > shots(${shots})`,
+              );
+            }
+          }
+        }
+
+        expect(violations).toHaveLength(0);
+      }),
+    );
   });
 
   describe("Cross-File Consistency", () => {
-    it("player slugs should be unique across all sources", () => {
-      const slugCounts = new Map<string, number>();
+    it.effect("player slugs should be unique across all sources", () =>
+      Effect.gen(function* () {
+        const playerDetails = yield* Ref.get(playerDetailsRef);
+        const slugCounts = new Map<string, number>();
 
-      for (const player of playerDetails) {
-        slugCounts.set(player.slug, (slugCounts.get(player.slug) ?? 0) + 1);
-      }
+        for (const player of playerDetails) {
+          slugCounts.set(player.slug, (slugCounts.get(player.slug) ?? 0) + 1);
+        }
 
-      const duplicates = [...slugCounts.entries()].filter(
-        ([, count]) => count > 1,
-      );
-      expect(duplicates).toHaveLength(0);
-    });
-
-    it("player officialIds should be unique in player-details", () => {
-      const idCounts = new Map<string, number>();
-
-      for (const player of playerDetails) {
-        idCounts.set(
-          player.officialId,
-          (idCounts.get(player.officialId) ?? 0) + 1,
+        const duplicates = [...slugCounts.entries()].filter(
+          ([, count]) => count > 1,
         );
-      }
+        expect(duplicates).toHaveLength(0);
+      }),
+    );
 
-      const duplicates = [...idCounts.entries()].filter(
-        ([, count]) => count > 1,
-      );
-      expect(duplicates).toHaveLength(0);
-    });
+    it.effect("player officialIds should be unique in player-details", () =>
+      Effect.gen(function* () {
+        const playerDetails = yield* Ref.get(playerDetailsRef);
+        const idCounts = new Map<string, number>();
 
-    it("career stats totals should roughly match sum of season stats", () => {
-      const violations: string[] = [];
-
-      for (const player of playerDetails) {
-        if (!player.careerStats || player.allSeasonStats.length === 0) continue;
-
-        const seasonTotals = player.allSeasonStats.reduce(
-          (acc, s) => ({
-            goals: acc.goals + s.goals,
-            assists: acc.assists + s.assists,
-            gamesPlayed: acc.gamesPlayed + s.gamesPlayed,
-          }),
-          { goals: 0, assists: 0, gamesPlayed: 0 },
-        );
-
-        const goalDiff = Math.abs(
-          seasonTotals.goals - player.careerStats.goals,
-        );
-        const assistDiff = Math.abs(
-          seasonTotals.assists - player.careerStats.assists,
-        );
-
-        if (goalDiff > 5 || assistDiff > 5) {
-          violations.push(
-            `${player.firstName} ${player.lastName}: career(${player.careerStats.goals}g/${player.careerStats.assists}a) vs seasons(${seasonTotals.goals}g/${seasonTotals.assists}a)`,
+        for (const player of playerDetails) {
+          idCounts.set(
+            player.officialId,
+            (idCounts.get(player.officialId) ?? 0) + 1,
           );
         }
-      }
 
-      if (violations.length > 0) {
-        console.warn(`Career/season stat mismatches: ${violations.length}`);
-        console.warn(violations.slice(0, 5).join("\n"));
-      }
-      expect(violations.length).toBeLessThan(50);
-    });
+        const duplicates = [...idCounts.entries()].filter(
+          ([, count]) => count > 1,
+        );
+        expect(duplicates).toHaveLength(0);
+      }),
+    );
+
+    it.effect(
+      "career stats totals should roughly match sum of season stats",
+      () =>
+        Effect.gen(function* () {
+          const playerDetails = yield* Ref.get(playerDetailsRef);
+          const violations: string[] = [];
+
+          for (const player of playerDetails) {
+            if (!player.careerStats || player.allSeasonStats.length === 0)
+              continue;
+
+            const seasonTotals = player.allSeasonStats.reduce(
+              (acc, s) => ({
+                goals: acc.goals + s.goals,
+                assists: acc.assists + s.assists,
+                gamesPlayed: acc.gamesPlayed + s.gamesPlayed,
+              }),
+              { goals: 0, assists: 0, gamesPlayed: 0 },
+            );
+
+            const goalDiff = Math.abs(
+              seasonTotals.goals - player.careerStats.goals,
+            );
+            const assistDiff = Math.abs(
+              seasonTotals.assists - player.careerStats.assists,
+            );
+
+            if (goalDiff > 5 || assistDiff > 5) {
+              violations.push(
+                `${player.firstName} ${player.lastName}: career(${player.careerStats.goals}g/${player.careerStats.assists}a) vs seasons(${seasonTotals.goals}g/${seasonTotals.assists}a)`,
+              );
+            }
+          }
+
+          if (violations.length > 0) {
+            console.warn(`Career/season stat mismatches: ${violations.length}`);
+            console.warn(violations.slice(0, 5).join("\n"));
+          }
+          expect(violations.length).toBeLessThan(50);
+        }),
+    );
   });
 
   describe("Data Completeness", () => {
-    it("should have player details for all years", () => {
-      expect(playerDetails.length).toBeGreaterThan(400);
-    });
+    it.effect("should have player details for all years", () =>
+      Effect.gen(function* () {
+        const playerDetails = yield* Ref.get(playerDetailsRef);
+        expect(playerDetails.length).toBeGreaterThan(400);
+      }),
+    );
 
-    it("should have career stats for PLL and MLL players", () => {
-      const pllCount = careerStats.filter(
-        (p) => p.likelySource === "pll",
-      ).length;
-      const mllCount = careerStats.filter(
-        (p) => p.likelySource === "mll_or_retired",
-      ).length;
+    it.effect("should have career stats for PLL and MLL players", () =>
+      Effect.gen(function* () {
+        const careerStats = yield* Ref.get(careerStatsRef);
+        const pllCount = careerStats.filter(
+          (p) => p.likelySource === "pll",
+        ).length;
+        const mllCount = careerStats.filter(
+          (p) => p.likelySource === "mll_or_retired",
+        ).length;
 
-      expect(pllCount).toBeGreaterThan(300);
-      expect(mllCount).toBeGreaterThan(700);
-    });
+        expect(pllCount).toBeGreaterThan(300);
+        expect(mllCount).toBeGreaterThan(700);
+      }),
+    );
 
-    it("should have data for all PLL years (2019-2025)", () => {
-      for (const year of YEARS) {
-        expect(yearPlayers[year]?.length).toBeGreaterThan(100);
-        expect(yearTeams[year]?.length).toBeGreaterThanOrEqual(6);
-      }
-    });
+    it.effect("should have data for all PLL years (2019-2025)", () =>
+      Effect.gen(function* () {
+        const yearPlayers = yield* Ref.get(yearPlayersRef);
+        const yearTeams = yield* Ref.get(yearTeamsRef);
 
-    it("2019 should have 6 teams, 2020 should have 7, 2021+ should have 8", () => {
-      expect(yearTeams["2019"]?.length).toBe(6);
-      expect(yearTeams["2020"]?.length).toBe(7);
-      expect(yearTeams["2021"]?.length).toBe(8);
-      expect(yearTeams["2022"]?.length).toBe(8);
-      expect(yearTeams["2023"]?.length).toBe(8);
-      expect(yearTeams["2024"]?.length).toBe(8);
-      expect(yearTeams["2025"]?.length).toBe(8);
-    });
+        for (const year of YEARS) {
+          expect(yearPlayers[year]?.length).toBeGreaterThan(100);
+          expect(yearTeams[year]?.length).toBeGreaterThanOrEqual(6);
+        }
+      }),
+    );
+
+    it.effect(
+      "2019 should have 6 teams, 2020 should have 7, 2021+ should have 8",
+      () =>
+        Effect.gen(function* () {
+          const yearTeams = yield* Ref.get(yearTeamsRef);
+
+          expect(yearTeams["2019"]?.length).toBe(6);
+          expect(yearTeams["2020"]?.length).toBe(7);
+          expect(yearTeams["2021"]?.length).toBe(8);
+          expect(yearTeams["2022"]?.length).toBe(8);
+          expect(yearTeams["2023"]?.length).toBe(8);
+          expect(yearTeams["2024"]?.length).toBe(8);
+          expect(yearTeams["2025"]?.length).toBe(8);
+        }),
+    );
   });
 });

--- a/packages/pipeline/src/validate/validate.service.test.ts
+++ b/packages/pipeline/src/validate/validate.service.test.ts
@@ -1,8 +1,7 @@
+import { FileSystem, Path } from "@effect/platform";
+import { BunContext } from "@effect/platform-bun";
+import { describe, it, expect, layer } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, expect, it, beforeAll, afterAll } from "vitest";
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
-import * as os from "node:os";
 import {
   validateFileExists,
   validateJsonArray,
@@ -12,271 +11,301 @@ import {
   buildReport,
 } from "./validate.service";
 
-describe("validateFileExists", () => {
-  let tempDir: string;
-
-  beforeAll(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "validate-test-"));
-  });
-
-  afterAll(async () => {
-    await fs.rm(tempDir, { recursive: true });
-  });
-
-  it("returns exists: true for existing file", async () => {
-    const filePath = path.join(tempDir, "test.json");
-    await fs.writeFile(filePath, "[]");
-
-    const result = await Effect.runPromise(validateFileExists(filePath));
-
-    expect(result.exists).toBe(true);
-    expect(result.filePath).toBe(filePath);
-    expect(result.sizeBytes).toBeGreaterThan(0);
-    expect(result.checks[0]?.passed).toBe(true);
-  });
-
-  it("returns exists: false for missing file", async () => {
-    const filePath = path.join(tempDir, "nonexistent.json");
-
-    const result = await Effect.runPromise(validateFileExists(filePath));
-
-    expect(result.exists).toBe(false);
-    expect(result.checks[0]?.passed).toBe(false);
-    expect(result.checks[0]?.issues[0]?.code).toBe("FILE_NOT_FOUND");
-  });
+const makeTempDir = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const tempBase = yield* fs.makeTempDirectoryScoped();
+  return path.join(tempBase, "validate-test");
 });
 
-describe("validateJsonArray", () => {
-  let tempDir: string;
+layer(BunContext.layer)("validateFileExists", (it) => {
+  it.scoped("returns exists: true for existing file", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* makeTempDir;
+      yield* fs.makeDirectory(tempDir, { recursive: true });
+      const filePath = path.join(tempDir, "test.json");
+      yield* fs.writeFileString(filePath, "[]");
 
-  beforeAll(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "validate-test-"));
-  });
+      const result = yield* validateFileExists(filePath);
 
-  afterAll(async () => {
-    await fs.rm(tempDir, { recursive: true });
-  });
+      expect(result.exists).toBe(true);
+      expect(result.filePath).toBe(filePath);
+      expect(result.sizeBytes).toBeGreaterThan(0);
+      expect(result.checks[0]?.passed).toBe(true);
+    }),
+  );
 
-  it("validates valid JSON array", async () => {
-    const filePath = path.join(tempDir, "valid.json");
-    await fs.writeFile(filePath, JSON.stringify([{ id: 1 }, { id: 2 }]));
+  it.scoped("returns exists: false for missing file", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const tempDir = yield* makeTempDir;
+      const filePath = path.join(tempDir, "nonexistent.json");
 
-    const { result, data } = await Effect.runPromise(
-      validateJsonArray<{ id: number }>(filePath),
-    );
+      const result = yield* validateFileExists(filePath);
 
-    expect(result.exists).toBe(true);
-    expect(result.recordCount).toBe(2);
-    expect(data).toHaveLength(2);
-    expect(result.checks.every((c) => c.passed)).toBe(true);
-  });
+      expect(result.exists).toBe(false);
+      expect(result.checks[0]?.passed).toBe(false);
+      expect(result.checks[0]?.issues[0]?.code).toBe("FILE_NOT_FOUND");
+    }),
+  );
+});
 
-  it("fails when JSON is not an array", async () => {
-    const filePath = path.join(tempDir, "object.json");
-    await fs.writeFile(filePath, JSON.stringify({ key: "value" }));
+layer(BunContext.layer)("validateJsonArray", (it) => {
+  it.scoped("validates valid JSON array", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* makeTempDir;
+      yield* fs.makeDirectory(tempDir, { recursive: true });
+      const filePath = path.join(tempDir, "valid.json");
+      yield* fs.writeFileString(
+        filePath,
+        JSON.stringify([{ id: 1 }, { id: 2 }]),
+      );
 
-    const { result } = await Effect.runPromise(validateJsonArray(filePath));
+      const { result, data } = yield* validateJsonArray<{ id: number }>(
+        filePath,
+      );
 
-    expect(result.exists).toBe(true);
-    const parseCheck = result.checks.find((c) => c.checkName === "json_parse");
-    expect(parseCheck?.passed).toBe(false);
-    expect(parseCheck?.issues[0]?.code).toBe("NOT_ARRAY");
-  });
+      expect(result.exists).toBe(true);
+      expect(result.recordCount).toBe(2);
+      expect(data).toHaveLength(2);
+      expect(result.checks.every((c) => c.passed)).toBe(true);
+    }),
+  );
 
-  it("fails when array has fewer records than minimum", async () => {
-    const filePath = path.join(tempDir, "small.json");
-    await fs.writeFile(filePath, JSON.stringify([{ id: 1 }]));
+  it.scoped("fails when JSON is not an array", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* makeTempDir;
+      yield* fs.makeDirectory(tempDir, { recursive: true });
+      const filePath = path.join(tempDir, "object.json");
+      yield* fs.writeFileString(filePath, JSON.stringify({ key: "value" }));
 
-    const { result } = await Effect.runPromise(validateJsonArray(filePath, 10));
+      const { result } = yield* validateJsonArray(filePath);
 
-    const parseCheck = result.checks.find((c) => c.checkName === "json_parse");
-    expect(parseCheck?.passed).toBe(false);
-    expect(parseCheck?.issues[0]?.code).toBe("INSUFFICIENT_RECORDS");
-  });
+      expect(result.exists).toBe(true);
+      const parseCheck = result.checks.find(
+        (c) => c.checkName === "json_parse",
+      );
+      expect(parseCheck?.passed).toBe(false);
+      expect(parseCheck?.issues[0]?.code).toBe("NOT_ARRAY");
+    }),
+  );
 
-  it("returns empty data for missing file", async () => {
-    const filePath = path.join(tempDir, "missing.json");
+  it.scoped("fails when array has fewer records than minimum", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* makeTempDir;
+      yield* fs.makeDirectory(tempDir, { recursive: true });
+      const filePath = path.join(tempDir, "small.json");
+      yield* fs.writeFileString(filePath, JSON.stringify([{ id: 1 }]));
 
-    const { result, data } = await Effect.runPromise(
-      validateJsonArray(filePath),
-    );
+      const { result } = yield* validateJsonArray(filePath, 10);
 
-    expect(result.exists).toBe(false);
-    expect(data).toHaveLength(0);
-  });
+      const parseCheck = result.checks.find(
+        (c) => c.checkName === "json_parse",
+      );
+      expect(parseCheck?.passed).toBe(false);
+      expect(parseCheck?.issues[0]?.code).toBe("INSUFFICIENT_RECORDS");
+    }),
+  );
+
+  it.scoped("returns empty data for missing file", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const tempDir = yield* makeTempDir;
+      const filePath = path.join(tempDir, "missing.json");
+
+      const { result, data } = yield* validateJsonArray(filePath);
+
+      expect(result.exists).toBe(false);
+      expect(data).toHaveLength(0);
+    }),
+  );
 });
 
 describe("validateRequiredFields", () => {
-  it("passes when all required fields present", async () => {
-    const data = [
-      { id: "1", name: "Alice" },
-      { id: "2", name: "Bob" },
-    ];
+  it.effect("passes when all required fields present", () =>
+    Effect.gen(function* () {
+      const data = [
+        { id: "1", name: "Alice" },
+        { id: "2", name: "Bob" },
+      ];
 
-    const result = await Effect.runPromise(
-      validateRequiredFields(data, ["id", "name"]),
-    );
+      const result = yield* validateRequiredFields(data, ["id", "name"]);
 
-    expect(result.passed).toBe(true);
-    expect(result.issues).toHaveLength(0);
-  });
+      expect(result.passed).toBe(true);
+      expect(result.issues).toHaveLength(0);
+    }),
+  );
 
-  it("fails when field is missing in all records", async () => {
-    const data = [
-      { id: "1", name: null },
-      { id: "2", name: null },
-    ];
+  it.effect("fails when field is missing in all records", () =>
+    Effect.gen(function* () {
+      const data = [
+        { id: "1", name: null },
+        { id: "2", name: null },
+      ];
 
-    const result = await Effect.runPromise(
-      validateRequiredFields(data, ["id", "name"]),
-    );
+      const result = yield* validateRequiredFields(data, ["id", "name"]);
 
-    expect(result.passed).toBe(false);
-    expect(result.issues[0]?.code).toBe("FIELD_ALL_MISSING");
-  });
+      expect(result.passed).toBe(false);
+      expect(result.issues[0]?.code).toBe("FIELD_ALL_MISSING");
+    }),
+  );
 
-  it("warns when field is missing in most records", async () => {
-    const data = [
-      { id: "1", name: "Alice" },
-      { id: "2", name: null },
-      { id: "3", name: null },
-      { id: "4", name: null },
-    ];
+  it.effect("warns when field is missing in most records", () =>
+    Effect.gen(function* () {
+      const data = [
+        { id: "1", name: "Alice" },
+        { id: "2", name: null },
+        { id: "3", name: null },
+        { id: "4", name: null },
+      ];
 
-    const result = await Effect.runPromise(
-      validateRequiredFields(data, ["id", "name"]),
-    );
+      const result = yield* validateRequiredFields(data, ["id", "name"]);
 
-    expect(result.passed).toBe(true);
-    const nameIssue = result.issues.find((i) => i.message.includes("name"));
-    expect(nameIssue?.severity).toBe("warning");
-    expect(nameIssue?.code).toBe("FIELD_MOSTLY_MISSING");
-  });
+      expect(result.passed).toBe(true);
+      const nameIssue = result.issues.find((i) => i.message.includes("name"));
+      expect(nameIssue?.severity).toBe("warning");
+      expect(nameIssue?.code).toBe("FIELD_MOSTLY_MISSING");
+    }),
+  );
 
-  it("reports info when field is missing in few records", async () => {
-    const data = [
-      { id: "1", name: "Alice" },
-      { id: "2", name: "Bob" },
-      { id: "3", name: "Carol" },
-      { id: "4", name: null },
-    ];
+  it.effect("reports info when field is missing in few records", () =>
+    Effect.gen(function* () {
+      const data = [
+        { id: "1", name: "Alice" },
+        { id: "2", name: "Bob" },
+        { id: "3", name: "Carol" },
+        { id: "4", name: null },
+      ];
 
-    const result = await Effect.runPromise(
-      validateRequiredFields(data, ["id", "name"]),
-    );
+      const result = yield* validateRequiredFields(data, ["id", "name"]);
 
-    expect(result.passed).toBe(true);
-    const nameIssue = result.issues.find((i) => i.message.includes("name"));
-    expect(nameIssue?.severity).toBe("info");
-    expect(nameIssue?.code).toBe("FIELD_SOME_MISSING");
-  });
+      expect(result.passed).toBe(true);
+      const nameIssue = result.issues.find((i) => i.message.includes("name"));
+      expect(nameIssue?.severity).toBe("info");
+      expect(nameIssue?.code).toBe("FIELD_SOME_MISSING");
+    }),
+  );
 });
 
 describe("validateUniqueField", () => {
-  it("passes when all values are unique", async () => {
-    const data = [
-      { id: "1", name: "Alice" },
-      { id: "2", name: "Bob" },
-      { id: "3", name: "Carol" },
-    ];
+  it.effect("passes when all values are unique", () =>
+    Effect.gen(function* () {
+      const data = [
+        { id: "1", name: "Alice" },
+        { id: "2", name: "Bob" },
+        { id: "3", name: "Carol" },
+      ];
 
-    const result = await Effect.runPromise(validateUniqueField(data, "id"));
+      const result = yield* validateUniqueField(data, "id");
 
-    expect(result.passed).toBe(true);
-    expect(result.issues).toHaveLength(0);
-  });
+      expect(result.passed).toBe(true);
+      expect(result.issues).toHaveLength(0);
+    }),
+  );
 
-  it("fails when duplicates exist", async () => {
-    const data = [
-      { id: "1", name: "Alice" },
-      { id: "1", name: "Bob" },
-      { id: "2", name: "Carol" },
-    ];
+  it.effect("fails when duplicates exist", () =>
+    Effect.gen(function* () {
+      const data = [
+        { id: "1", name: "Alice" },
+        { id: "1", name: "Bob" },
+        { id: "2", name: "Carol" },
+      ];
 
-    const result = await Effect.runPromise(validateUniqueField(data, "id"));
+      const result = yield* validateUniqueField(data, "id");
 
-    expect(result.passed).toBe(false);
-    expect(result.issues[0]?.code).toBe("DUPLICATE_VALUES");
-  });
+      expect(result.passed).toBe(false);
+      expect(result.issues[0]?.code).toBe("DUPLICATE_VALUES");
+    }),
+  );
 
-  it("ignores null values when checking uniqueness", async () => {
-    const data = [
-      { id: null, name: "Alice" },
-      { id: null, name: "Bob" },
-      { id: "1", name: "Carol" },
-    ];
+  it.effect("ignores null values when checking uniqueness", () =>
+    Effect.gen(function* () {
+      const data = [
+        { id: null, name: "Alice" },
+        { id: null, name: "Bob" },
+        { id: "1", name: "Carol" },
+      ];
 
-    const result = await Effect.runPromise(validateUniqueField(data, "id"));
+      const result = yield* validateUniqueField(data, "id");
 
-    expect(result.passed).toBe(true);
-  });
+      expect(result.passed).toBe(true);
+    }),
+  );
 });
 
 describe("crossReference", () => {
-  it("returns full match when all source values exist in target", async () => {
-    const source = [{ foreignKey: "A" }, { foreignKey: "B" }];
-    const target = [{ id: "A" }, { id: "B" }, { id: "C" }];
+  it.effect("returns full match when all source values exist in target", () =>
+    Effect.gen(function* () {
+      const source = [{ foreignKey: "A" }, { foreignKey: "B" }];
+      const target = [{ id: "A" }, { id: "B" }, { id: "C" }];
 
-    const result = await Effect.runPromise(
-      crossReference(
+      const result = yield* crossReference(
         source,
         target,
         "foreignKey",
         "id",
         "source.json",
         "target.json",
-      ),
-    );
+      );
 
-    expect(result.totalSourceRecords).toBe(2);
-    expect(result.matchedRecords).toBe(2);
-    expect(result.unmatchedRecords).toBe(0);
-    expect(result.unmatchedSamples).toBeUndefined();
-  });
+      expect(result.totalSourceRecords).toBe(2);
+      expect(result.matchedRecords).toBe(2);
+      expect(result.unmatchedRecords).toBe(0);
+      expect(result.unmatchedSamples).toBeUndefined();
+    }),
+  );
 
-  it("returns partial match when some values missing", async () => {
-    const source = [
-      { foreignKey: "A" },
-      { foreignKey: "B" },
-      { foreignKey: "X" },
-    ];
-    const target = [{ id: "A" }, { id: "B" }];
+  it.effect("returns partial match when some values missing", () =>
+    Effect.gen(function* () {
+      const source = [
+        { foreignKey: "A" },
+        { foreignKey: "B" },
+        { foreignKey: "X" },
+      ];
+      const target = [{ id: "A" }, { id: "B" }];
 
-    const result = await Effect.runPromise(
-      crossReference(
+      const result = yield* crossReference(
         source,
         target,
         "foreignKey",
         "id",
         "source.json",
         "target.json",
-      ),
-    );
+      );
 
-    expect(result.totalSourceRecords).toBe(3);
-    expect(result.matchedRecords).toBe(2);
-    expect(result.unmatchedRecords).toBe(1);
-    expect(result.unmatchedSamples).toContain("X");
-  });
+      expect(result.totalSourceRecords).toBe(3);
+      expect(result.matchedRecords).toBe(2);
+      expect(result.unmatchedRecords).toBe(1);
+      expect(result.unmatchedSamples).toContain("X");
+    }),
+  );
 
-  it("handles null values in source data", async () => {
-    const source = [{ foreignKey: "A" }, { foreignKey: null }];
-    const target = [{ id: "A" }];
+  it.effect("handles null values in source data", () =>
+    Effect.gen(function* () {
+      const source = [{ foreignKey: "A" }, { foreignKey: null }];
+      const target = [{ id: "A" }];
 
-    const result = await Effect.runPromise(
-      crossReference(
+      const result = yield* crossReference(
         source,
         target,
         "foreignKey",
         "id",
         "source.json",
         "target.json",
-      ),
-    );
+      );
 
-    expect(result.matchedRecords).toBe(1);
-    expect(result.unmatchedRecords).toBe(1);
-  });
+      expect(result.matchedRecords).toBe(1);
+      expect(result.unmatchedRecords).toBe(1);
+    }),
+  );
 });
 
 describe("buildReport", () => {


### PR DESCRIPTION
## Summary
Refactors pipeline extraction scripts and utilities to use Effect's platform-native file system and path modules instead of Node.js's `fs` and `path` modules. Also updates runtime execution to use `BunRuntime.runMain` with proper layer composition.

## Changes
- Replaced Node.js `fs/promises` with `@effect/platform` FileSystem service across all extraction scripts
- Replaced Node.js `path` with `@effect/platform` Path service
- Updated all file operations to use Effect-based APIs (readFileString, writeFileString, makeDirectory, exists)
- Migrated from `Effect.runPromise` to `BunRuntime.runMain` for proper runtime execution
- Updated service dependencies to include `BunContext.layer` for platform compatibility
- Consolidated layer composition using `Layer.mergeAll` and `Layer.merge`
- Added `readJsonFile` utility to core package for shared JSON file reading
- Improved error handling with Effect's catchAll/catchAllCause patterns
- Updated test files to use `@effect/vitest` with Effect-based setup
- Updated TODO checklist marking Node fs migration as complete
- Minor dependency update: turbo 2.7.2 → 2.7.3

## Type
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other

## Notes
This refactor improves type safety and consistency by standardizing on Effect's platform abstractions throughout the pipeline package. All file operations now follow Effect's error handling patterns, making the code more maintainable and composable.

---
*Auto-generated by Claude. Feel free to edit.*
