### PR TITLE
feat(web): add React Compiler for automatic optimizations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@typescript/native-preview": "^7.0.0-dev.20251230.1",
         "@vitest/coverage-v8": "^4.0.16",
         "@vitest/ui": "^4.0.16",
+        "babel-plugin-react-compiler": "^1.0.0",
         "miniflare": "^4.20251217.0",
         "oxfmt": "^0.19.0",
         "oxlint": "^1.36.0",
@@ -1365,6 +1366,8 @@
     "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.11", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-mwq3W3e/pKSI6TG8lXMiDWvEi1VXYlSBlJlB3l+I0bAb5u1RNUl88udos85eOPNK3m5EXK9uO7d2g08pesTySQ=="],
+
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@1.0.0", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@typescript/native-preview": "^7.0.0-dev.20251230.1",
     "@vitest/coverage-v8": "^4.0.16",
     "@vitest/ui": "^4.0.16",
+    "babel-plugin-react-compiler": "^1.0.0",
     "miniflare": "^4.20251217.0",
     "oxfmt": "^0.19.0",
     "oxlint": "^1.36.0",

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -19,7 +19,11 @@ const config = defineConfig({
     alchemy(),
     tailwindcss(),
     tanstackStart(),
-    viteReact(),
+    viteReact({
+      babel: {
+             plugins: ['babel-plugin-react-compiler'],
+           },
+    }),
   ],
   css: {
     modules: {


### PR DESCRIPTION
## Summary
Integrates the React Compiler (formerly React Forget) to automatically optimize React components by memoizing expensive computations and preventing unnecessary re-renders.

## Changes
- Added `babel-plugin-react-compiler` dependency to root package.json
- Configured Vite React plugin in `packages/web/vite.config.ts` to use the React Compiler babel plugin
- Compiler will automatically optimize components without manual `useMemo`/`useCallback` usage

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other

## Notes
The React Compiler is production-ready as of React 19 and automatically applies optimizations that previously required manual memoization. This should improve rendering performance across the web package without code changes to existing components.

---
*Auto-generated by Claude. Feel free to edit.*
