### PR TITLE
fix: use stage_fixed instead of git update-index --again

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,8 @@ pre-commit:
   commands:
     fix:
       glob: "*.{js,ts,jsx,tsx}"
-      run: bun run fix && git update-index --again
+      run: bun run fix
+      stage_fixed: true
     typecheck:
       run: bun run typecheck
 


### PR DESCRIPTION
## Summary
- Replace dangerous `git update-index --again` with lefthook's built-in `stage_fixed: true`
- The manual index manipulation was causing corruption when running in parallel with typecheck

## Root Cause
The `git update-index --again` command in pre-commit was racing with parallel commands and corrupting the git index, causing all files to appear as deleted.

## Solution
Lefthook has a built-in `stage_fixed: true` option designed specifically for re-staging files after lint/format operations. It uses `git add` under the hood which is safer than direct index manipulation.

## Test Plan
- [x] Made test commit with new configuration
- [x] Verified index remained healthy (528 files, not just staged ones)
- [x] No corruption after commit

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)