### PR TITLE
refactor(pipeline): share fetch helpers across clients

### DIFF
--- a/packages/pipeline/src/api-client/config.schema.ts
+++ b/packages/pipeline/src/api-client/config.schema.ts
@@ -1,0 +1,11 @@
+import { Schema } from "effect";
+
+export const SharedClientConfigFields = {
+  defaultHeaders: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  authHeader: Schema.optional(Schema.String),
+  timeoutMs: Schema.optional(Schema.Number.check(Schema.isGreaterThan(0))),
+  maxRetries: Schema.optional(
+    Schema.Number.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0)),
+  ),
+  retryDelayMs: Schema.optional(Schema.Number.check(Schema.isGreaterThan(0))),
+} as const;

--- a/packages/pipeline/src/api-client/graphql.schema.ts
+++ b/packages/pipeline/src/api-client/graphql.schema.ts
@@ -1,16 +1,12 @@
 import { Schema } from "effect";
 
+import { SharedClientConfigFields } from "./config.schema";
+
 export class GraphQLClientConfig extends Schema.Class<GraphQLClientConfig>(
   "GraphQLClientConfig",
 )({
   endpoint: Schema.String,
-  defaultHeaders: Schema.optional(Schema.Record(Schema.String, Schema.String)),
-  authHeader: Schema.optional(Schema.String),
-  timeoutMs: Schema.optional(Schema.Number.check(Schema.isGreaterThan(0))),
-  maxRetries: Schema.optional(
-    Schema.Number.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0)),
-  ),
-  retryDelayMs: Schema.optional(Schema.Number.check(Schema.isGreaterThan(0))),
+  ...SharedClientConfigFields,
 }) {}
 
 export class GraphQLRequest extends Schema.Class<GraphQLRequest>(

--- a/packages/pipeline/src/api-client/graphql.service.ts
+++ b/packages/pipeline/src/api-client/graphql.service.ts
@@ -1,26 +1,14 @@
-import { Duration, Effect, Schedule, Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 import { DEFAULT_PIPELINE_CONFIG } from "../config";
-import {
-  GraphQLError,
-  HttpError,
-  NetworkError,
-  ParseError,
-  type PipelineError,
-  RateLimitError,
-  TimeoutError,
-} from "../error";
+import { GraphQLError, ParseError, type PipelineError } from "../error";
+import { fetchJson, retryPipelineRequest } from "../http";
 
 import type { GraphQLClientConfig, GraphQLRequest } from "./graphql.schema";
 import { GraphQLResponse } from "./graphql.schema";
 
 // Re-export for backwards compatibility
 export { GraphQLError } from "../error";
-
-const MAX_RETRY_WAIT_MS = 300_000; // 5 minutes max to prevent DoS via large retry-after
-
-const isTransientError = (error: PipelineError): boolean =>
-  error instanceof NetworkError || error instanceof TimeoutError;
 
 export const makeGraphQLClient = (config: GraphQLClientConfig) => {
   const defaultTimeout =
@@ -51,81 +39,22 @@ export const makeGraphQLClient = (config: GraphQLClientConfig) => {
       const timeout = timeoutMs ?? defaultTimeout;
       const url = config.endpoint;
 
-      const response = yield* Effect.tryPromise({
-        try: (signal) =>
-          fetch(url, {
-            method: "POST",
-            headers: buildHeaders(),
-            body: JSON.stringify({
-              query: request.query,
-              variables: request.variables,
-              operationName: request.operationName,
-            }),
-            signal,
-          }),
-        catch: (error) => {
-          if (error instanceof Error && error.name === "AbortError") {
-            return new TimeoutError({
-              message: `Request timed out after ${timeout}ms`,
-              url,
-              timeoutMs: timeout,
-            });
-          }
-          return new NetworkError({
-            message: `Network error: ${String(error)}`,
-            url,
-            cause: error,
-          });
-        },
-      }).pipe(
-        Effect.timeoutOrElse({
-          duration: Duration.millis(timeout),
-          orElse: () =>
-            Effect.fail(
-              new TimeoutError({
-                message: `Request timed out after ${timeout}ms`,
-                url,
-                timeoutMs: timeout,
-              }),
-            ),
+      const json = yield* fetchJson({
+        url,
+        timeoutMs: timeout,
+        method: "POST",
+        headers: buildHeaders(),
+        body: JSON.stringify({
+          query: request.query,
+          variables: request.variables,
+          operationName: request.operationName,
         }),
-      );
-
-      if (response.status === 429) {
-        const retryAfter = response.headers.get("retry-after");
-        const retryAfterMs = retryAfter
-          ? Number.parseInt(retryAfter, 10) * 1000
-          : undefined;
-
-        return yield* Effect.fail(
-          new RateLimitError({
-            message: "Rate limited by server",
-            url,
-            retryAfterMs,
-          }),
-        );
-      }
-
-      if (!response.ok) {
-        return yield* Effect.fail(
-          new HttpError({
-            message: `HTTP ${response.status}: ${response.statusText}`,
-            url,
-            method: "POST",
-            statusCode: response.status,
-          }),
-        );
-      }
-
-      const json = yield* Effect.tryPromise({
-        try: () => response.json(),
-        catch: (error) =>
-          new HttpError({
-            message: `Failed to parse JSON: ${String(error)}`,
-            url,
-            method: "POST",
-            cause: error,
-          }),
+        timeoutMessage: `Request timed out after ${timeout}ms`,
+        networkMessage: (error) => `Network error: ${String(error)}`,
+        httpMessage: (statusCode, statusText) =>
+          `HTTP ${statusCode}: ${statusText}`,
+        rateLimitMessage: "Rate limited by server",
+        jsonParseMessage: (error) => `Failed to parse JSON: ${String(error)}`,
       });
 
       const responseSchema = GraphQLResponse(dataSchema);
@@ -172,29 +101,10 @@ export const makeGraphQLClient = (config: GraphQLClientConfig) => {
     dataSchema: S,
     timeoutMs?: number,
   ): Effect.Effect<S["Type"], PipelineError, S["DecodingServices"]> =>
-    execute(request, dataSchema, timeoutMs).pipe(
-      Effect.retry({
-        schedule: Schedule.exponential(Duration.millis(retryDelayMs)),
-        times: maxRetries,
-        while: isTransientError,
-      }),
-      Effect.catchTag("RateLimitError", (error) =>
-        Effect.sleep(
-          Duration.millis(
-            Math.min(error.retryAfterMs ?? retryDelayMs, MAX_RETRY_WAIT_MS),
-          ),
-        ).pipe(
-          Effect.andThen(
-            execute(request, dataSchema, timeoutMs).pipe(
-              Effect.retry({
-                schedule: Schedule.exponential(Duration.millis(retryDelayMs)),
-                times: maxRetries,
-              }),
-            ),
-          ),
-        ),
-      ),
-    );
+    retryPipelineRequest(() => execute(request, dataSchema, timeoutMs), {
+      maxRetries,
+      retryDelayMs,
+    });
 
   return {
     query: <S extends Schema.Top>(

--- a/packages/pipeline/src/api-client/graphql.service.ts
+++ b/packages/pipeline/src/api-client/graphql.service.ts
@@ -1,34 +1,25 @@
-import { Effect, Schema } from "effect";
+import { Effect, type Schema } from "effect";
 
-import { DEFAULT_PIPELINE_CONFIG } from "../config";
-import { GraphQLError, ParseError, type PipelineError } from "../error";
+import { GraphQLError, type PipelineError } from "../error";
 import { fetchJson, retryPipelineRequest } from "../http";
 
 import type { GraphQLClientConfig, GraphQLRequest } from "./graphql.schema";
 import { GraphQLResponse } from "./graphql.schema";
+import {
+  buildJsonHeaders,
+  decodeClientResponse,
+  resolveClientRuntimeConfig,
+} from "./shared";
 
 // Re-export for backwards compatibility
 export { GraphQLError } from "../error";
 
 export const makeGraphQLClient = (config: GraphQLClientConfig) => {
-  const defaultTimeout =
-    config.timeoutMs ?? DEFAULT_PIPELINE_CONFIG.defaultTimeoutMs;
-  const maxRetries = config.maxRetries ?? DEFAULT_PIPELINE_CONFIG.maxRetries;
-  const retryDelayMs =
-    config.retryDelayMs ?? DEFAULT_PIPELINE_CONFIG.retryDelayMs;
-
-  const buildHeaders = (): Record<string, string> => {
-    const headers: Record<string, string> = {
-      "content-type": "application/json",
-      ...config.defaultHeaders,
-    };
-
-    if (config.authHeader) {
-      headers.authorization = config.authHeader;
-    }
-
-    return headers;
-  };
+  const {
+    defaultTimeoutMs: defaultTimeout,
+    maxRetries,
+    retryDelayMs,
+  } = resolveClientRuntimeConfig(config);
 
   const execute = <S extends Schema.Top>(
     request: GraphQLRequest,
@@ -43,7 +34,7 @@ export const makeGraphQLClient = (config: GraphQLClientConfig) => {
         url,
         timeoutMs: timeout,
         method: "POST",
-        headers: buildHeaders(),
+        headers: buildJsonHeaders(config),
         body: JSON.stringify({
           query: request.query,
           variables: request.variables,
@@ -58,18 +49,7 @@ export const makeGraphQLClient = (config: GraphQLClientConfig) => {
       });
 
       const responseSchema = GraphQLResponse(dataSchema);
-      const decoded = yield* Schema.decodeUnknownEffect(responseSchema)(
-        json,
-      ).pipe(
-        Effect.mapError(
-          (error) =>
-            new ParseError({
-              message: `Schema validation failed: ${String(error)}`,
-              url,
-              cause: error,
-            }),
-        ),
-      );
+      const decoded = yield* decodeClientResponse(responseSchema, json, url);
 
       if (decoded.errors && decoded.errors.length > 0) {
         return yield* Effect.fail(

--- a/packages/pipeline/src/api-client/rest-client.schema.ts
+++ b/packages/pipeline/src/api-client/rest-client.schema.ts
@@ -1,16 +1,12 @@
 import { Schema } from "effect";
 
+import { SharedClientConfigFields } from "./config.schema";
+
 export class RestClientConfig extends Schema.Class<RestClientConfig>(
   "RestClientConfig",
 )({
   baseUrl: Schema.String,
-  defaultHeaders: Schema.optional(Schema.Record(Schema.String, Schema.String)),
-  authHeader: Schema.optional(Schema.String),
-  timeoutMs: Schema.optional(Schema.Number.check(Schema.isGreaterThan(0))),
-  maxRetries: Schema.optional(
-    Schema.Number.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0)),
-  ),
-  retryDelayMs: Schema.optional(Schema.Number.check(Schema.isGreaterThan(0))),
+  ...SharedClientConfigFields,
 }) {}
 
 export class RestRequestOptions extends Schema.Class<RestRequestOptions>(

--- a/packages/pipeline/src/api-client/rest-client.service.ts
+++ b/packages/pipeline/src/api-client/rest-client.service.ts
@@ -1,7 +1,6 @@
-import { Effect, Schema } from "effect";
+import { Effect, type Schema } from "effect";
 
-import { DEFAULT_PIPELINE_CONFIG } from "../config";
-import { ParseError, type PipelineError } from "../error";
+import type { PipelineError } from "../error";
 import { fetchJson, retryPipelineRequest } from "../http";
 
 import type {
@@ -9,29 +8,18 @@ import type {
   RestRequestOptions,
   HttpMethod,
 } from "./rest-client.schema";
+import {
+  buildJsonHeaders,
+  decodeClientResponse,
+  resolveClientRuntimeConfig,
+} from "./shared";
 
 export const makeRestClient = (config: RestClientConfig) => {
-  const defaultTimeout =
-    config.timeoutMs ?? DEFAULT_PIPELINE_CONFIG.defaultTimeoutMs;
-  const maxRetries = config.maxRetries ?? DEFAULT_PIPELINE_CONFIG.maxRetries;
-  const retryDelayMs =
-    config.retryDelayMs ?? DEFAULT_PIPELINE_CONFIG.retryDelayMs;
-
-  const buildHeaders = (
-    options?: RestRequestOptions,
-  ): Record<string, string> => {
-    const headers: Record<string, string> = {
-      "content-type": "application/json",
-      ...config.defaultHeaders,
-      ...options?.headers,
-    };
-
-    if (config.authHeader) {
-      headers.authorization = config.authHeader;
-    }
-
-    return headers;
-  };
+  const {
+    defaultTimeoutMs: defaultTimeout,
+    maxRetries,
+    retryDelayMs,
+  } = resolveClientRuntimeConfig(config);
 
   const request = <S extends Schema.Top>(
     method: HttpMethod,
@@ -48,7 +36,7 @@ export const makeRestClient = (config: RestClientConfig) => {
         url,
         timeoutMs,
         method,
-        headers: buildHeaders(options),
+        headers: buildJsonHeaders(config, options?.headers),
         ...(body ? { body: JSON.stringify(body) } : {}),
         timeoutMessage: `Request timed out after ${timeoutMs}ms`,
         networkMessage: (error) => `Network error: ${String(error)}`,
@@ -58,18 +46,7 @@ export const makeRestClient = (config: RestClientConfig) => {
         jsonParseMessage: (error) => `Failed to parse JSON: ${String(error)}`,
       });
 
-      const decoded = yield* Schema.decodeUnknownEffect(schema)(json).pipe(
-        Effect.mapError(
-          (error) =>
-            new ParseError({
-              message: `Schema validation failed: ${String(error)}`,
-              url,
-              cause: error,
-            }),
-        ),
-      );
-
-      return decoded;
+      return yield* decodeClientResponse(schema, json, url);
     });
 
   const requestWithRetry = <S extends Schema.Top>(

--- a/packages/pipeline/src/api-client/rest-client.service.ts
+++ b/packages/pipeline/src/api-client/rest-client.service.ts
@@ -1,26 +1,14 @@
-import { Duration, Effect, Schedule, Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 import { DEFAULT_PIPELINE_CONFIG } from "../config";
-
-const MAX_RETRY_WAIT_MS = 300_000; // 5 minutes max to prevent DoS via large retry-after
-import {
-  HttpError,
-  NetworkError,
-  ParseError,
-  type PipelineError,
-  RateLimitError,
-  TimeoutError,
-} from "../error";
+import { ParseError, type PipelineError } from "../error";
+import { fetchJson, retryPipelineRequest } from "../http";
 
 import type {
   RestClientConfig,
   RestRequestOptions,
   HttpMethod,
 } from "./rest-client.schema";
-
-// Retry transient transport failures only.
-const isTransientError = (error: PipelineError): boolean =>
-  error instanceof NetworkError || error instanceof TimeoutError;
 
 export const makeRestClient = (config: RestClientConfig) => {
   const defaultTimeout =
@@ -56,77 +44,18 @@ export const makeRestClient = (config: RestClientConfig) => {
       const url = `${config.baseUrl}${endpoint}`;
       const timeoutMs = options?.timeoutMs ?? defaultTimeout;
 
-      const response = yield* Effect.tryPromise({
-        try: (signal) =>
-          fetch(url, {
-            method,
-            headers: buildHeaders(options),
-            body: body ? JSON.stringify(body) : undefined,
-            signal,
-          }),
-        catch: (error) => {
-          if (error instanceof Error && error.name === "AbortError") {
-            return new TimeoutError({
-              message: `Request timed out after ${timeoutMs}ms`,
-              url,
-              timeoutMs,
-            });
-          }
-          return new NetworkError({
-            message: `Network error: ${String(error)}`,
-            url,
-            cause: error,
-          });
-        },
-      }).pipe(
-        Effect.timeoutOrElse({
-          duration: Duration.millis(timeoutMs),
-          orElse: () =>
-            Effect.fail(
-              new TimeoutError({
-                message: `Request timed out after ${timeoutMs}ms`,
-                url,
-                timeoutMs,
-              }),
-            ),
-        }),
-      );
-
-      if (response.status === 429) {
-        const retryAfter = response.headers.get("retry-after");
-        const retryAfterMs = retryAfter
-          ? Number.parseInt(retryAfter, 10) * 1000
-          : undefined;
-
-        return yield* Effect.fail(
-          new RateLimitError({
-            message: "Rate limited by server",
-            url,
-            retryAfterMs,
-          }),
-        );
-      }
-
-      if (!response.ok) {
-        return yield* Effect.fail(
-          new HttpError({
-            message: `HTTP ${response.status}: ${response.statusText}`,
-            url,
-            method,
-            statusCode: response.status,
-          }),
-        );
-      }
-
-      const json = yield* Effect.tryPromise({
-        try: () => response.json(),
-        catch: (error) =>
-          new HttpError({
-            message: `Failed to parse JSON: ${String(error)}`,
-            url,
-            method,
-            cause: error,
-          }),
+      const json = yield* fetchJson({
+        url,
+        timeoutMs,
+        method,
+        headers: buildHeaders(options),
+        ...(body ? { body: JSON.stringify(body) } : {}),
+        timeoutMessage: `Request timed out after ${timeoutMs}ms`,
+        networkMessage: (error) => `Network error: ${String(error)}`,
+        httpMessage: (statusCode, statusText) =>
+          `HTTP ${statusCode}: ${statusText}`,
+        rateLimitMessage: "Rate limited by server",
+        jsonParseMessage: (error) => `Failed to parse JSON: ${String(error)}`,
       });
 
       const decoded = yield* Schema.decodeUnknownEffect(schema)(json).pipe(
@@ -150,28 +79,12 @@ export const makeRestClient = (config: RestClientConfig) => {
     body?: unknown,
     options?: RestRequestOptions,
   ): Effect.Effect<S["Type"], PipelineError, S["DecodingServices"]> =>
-    request(method, endpoint, schema, body, options).pipe(
-      Effect.retry({
-        schedule: Schedule.exponential(Duration.millis(retryDelayMs)),
-        times: maxRetries,
-        while: isTransientError,
-      }),
-      Effect.catchTag("RateLimitError", (error) =>
-        Effect.sleep(
-          Duration.millis(
-            Math.min(error.retryAfterMs ?? retryDelayMs, MAX_RETRY_WAIT_MS),
-          ),
-        ).pipe(
-          Effect.andThen(
-            request(method, endpoint, schema, body, options).pipe(
-              Effect.retry({
-                schedule: Schedule.exponential(Duration.millis(retryDelayMs)),
-                times: maxRetries,
-              }),
-            ),
-          ),
-        ),
-      ),
+    retryPipelineRequest(
+      () => request(method, endpoint, schema, body, options),
+      {
+        maxRetries,
+        retryDelayMs,
+      },
     );
 
   return {

--- a/packages/pipeline/src/api-client/shared.ts
+++ b/packages/pipeline/src/api-client/shared.ts
@@ -1,0 +1,60 @@
+import { Effect, Schema } from "effect";
+
+import { DEFAULT_PIPELINE_CONFIG } from "../config";
+import { ParseError } from "../error";
+
+export interface SharedClientConfig {
+  readonly defaultHeaders?: Readonly<Record<string, string>> | undefined;
+  readonly authHeader?: string | undefined;
+  readonly timeoutMs?: number | undefined;
+  readonly maxRetries?: number | undefined;
+  readonly retryDelayMs?: number | undefined;
+}
+
+export interface ClientRuntimeConfig {
+  readonly defaultTimeoutMs: number;
+  readonly maxRetries: number;
+  readonly retryDelayMs: number;
+}
+
+export const resolveClientRuntimeConfig = (
+  config: SharedClientConfig,
+): ClientRuntimeConfig => ({
+  defaultTimeoutMs:
+    config.timeoutMs ?? DEFAULT_PIPELINE_CONFIG.defaultTimeoutMs,
+  maxRetries: config.maxRetries ?? DEFAULT_PIPELINE_CONFIG.maxRetries,
+  retryDelayMs: config.retryDelayMs ?? DEFAULT_PIPELINE_CONFIG.retryDelayMs,
+});
+
+export const buildJsonHeaders = (
+  config: Pick<SharedClientConfig, "defaultHeaders" | "authHeader">,
+  headers?: Readonly<Record<string, string>>,
+): Record<string, string> => {
+  const requestHeaders: Record<string, string> = {
+    "content-type": "application/json",
+    ...config.defaultHeaders,
+    ...headers,
+  };
+
+  if (config.authHeader) {
+    requestHeaders.authorization = config.authHeader;
+  }
+
+  return requestHeaders;
+};
+
+export const decodeClientResponse = <S extends Schema.Top>(
+  schema: S,
+  input: unknown,
+  url: string,
+): Effect.Effect<S["Type"], ParseError, S["DecodingServices"]> =>
+  Schema.decodeUnknownEffect(schema)(input).pipe(
+    Effect.mapError(
+      (error) =>
+        new ParseError({
+          message: `Schema validation failed: ${String(error)}`,
+          url,
+          cause: error,
+        }),
+    ),
+  );

--- a/packages/pipeline/src/http.ts
+++ b/packages/pipeline/src/http.ts
@@ -4,6 +4,21 @@ import type { PipelineConfigValues } from "./config";
 import { HttpError, NetworkError, TimeoutError } from "./error";
 import { formatUnknownError } from "./util";
 
+export interface FetchResponseRequest<ETimeout, ENetwork> {
+  readonly url: string;
+  readonly timeoutMs: number;
+  readonly method?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly redirect?: "follow" | "error" | "manual";
+  readonly timeoutError: (url: string, timeoutMs: number) => ETimeout;
+  readonly networkError: (url: string, error: unknown) => ENetwork;
+}
+
+export interface ReadResponseTextRequest<EBodyRead> {
+  readonly url: string;
+  readonly bodyReadError: (url: string, error: unknown) => EBodyRead;
+}
+
 export interface FetchTextRequest {
   readonly url: string;
   readonly timeoutMs: number;
@@ -16,67 +31,96 @@ export interface FetchTextRequest {
   readonly bodyReadMessage: (error: unknown) => string;
 }
 
-export const fetchText = Effect.fn("pipeline.fetchText")(function* (
-  request: FetchTextRequest,
-) {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => {
-    controller.abort();
-  }, request.timeoutMs);
+export const fetchResponse = <ETimeout, ENetwork>(
+  request: FetchResponseRequest<ETimeout, ENetwork>,
+): Effect.Effect<Response, ETimeout | ENetwork> =>
+  Effect.gen(function* () {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, request.timeoutMs);
 
-  const requestInit = {
-    method: request.method ?? "GET",
-    headers: request.headers,
-    signal: controller.signal,
-    ...(request.redirect ? { redirect: request.redirect } : {}),
-  };
+    const requestInit = {
+      method: request.method ?? "GET",
+      headers: request.headers,
+      signal: controller.signal,
+      ...(request.redirect ? { redirect: request.redirect } : {}),
+    };
 
-  const response = yield* Effect.tryPromise({
-    try: () => fetch(request.url, requestInit),
-    catch: (error) => {
-      if (error instanceof Error && error.name === "AbortError") {
-        return new TimeoutError({
-          message: request.timeoutMessage,
-          url: request.url,
-          timeoutMs: request.timeoutMs,
-        });
-      }
+    return yield* Effect.tryPromise({
+      try: () => fetch(request.url, requestInit),
+      catch: (error) => {
+        if (error instanceof Error && error.name === "AbortError") {
+          return request.timeoutError(request.url, request.timeoutMs);
+        }
 
-      return new NetworkError({
-        message: request.networkMessage(error),
-        url: request.url,
-        cause: error,
-      });
-    },
-  }).pipe(
-    Effect.ensuring(
-      Effect.sync(() => {
-        clearTimeout(timeoutId);
-      }),
-    ),
-  );
-
-  if (response.status >= 400) {
-    return yield* Effect.fail(
-      new HttpError({
-        message: request.httpMessage(response.status),
-        url: request.url,
-        method: request.method ?? "GET",
-        statusCode: response.status,
-      }),
+        return request.networkError(request.url, error);
+      },
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          clearTimeout(timeoutId);
+        }),
+      ),
     );
-  }
-
-  return yield* Effect.tryPromise({
-    try: () => response.text(),
-    catch: (error) =>
-      new NetworkError({
-        message: request.bodyReadMessage(error),
-        url: request.url,
-        cause: error,
-      }),
   });
-});
+
+export const readResponseText = <EBodyRead>(
+  response: Response,
+  request: ReadResponseTextRequest<EBodyRead>,
+): Effect.Effect<string, EBodyRead> =>
+  Effect.tryPromise({
+    try: () => response.text(),
+    catch: (error) => request.bodyReadError(request.url, error),
+  });
+
+export const fetchText = (
+  request: FetchTextRequest,
+): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
+  Effect.gen(function* () {
+    const responseRequest: FetchResponseRequest<TimeoutError, NetworkError> = {
+      url: request.url,
+      timeoutMs: request.timeoutMs,
+      timeoutError: (url, timeoutMs) =>
+        new TimeoutError({
+          message: request.timeoutMessage,
+          url,
+          timeoutMs,
+        }),
+      networkError: (url, error) =>
+        new NetworkError({
+          message: request.networkMessage(error),
+          url,
+          cause: error,
+        }),
+      ...(request.method ? { method: request.method } : {}),
+      ...(request.headers ? { headers: request.headers } : {}),
+      ...(request.redirect ? { redirect: request.redirect } : {}),
+    };
+
+    const response = yield* fetchResponse(responseRequest);
+
+    if (response.status >= 400) {
+      return yield* Effect.fail(
+        new HttpError({
+          message: request.httpMessage(response.status),
+          url: request.url,
+          method: request.method ?? "GET",
+          statusCode: response.status,
+        }),
+      );
+    }
+
+    return yield* readResponseText(response, {
+      url: request.url,
+      bodyReadError: (url, error) =>
+        new NetworkError({
+          message: request.bodyReadMessage(error),
+          url,
+          cause: error,
+        }),
+    });
+  });
 
 export const fetchTextWithRetry = (
   request: FetchTextRequest,

--- a/packages/pipeline/src/http.ts
+++ b/packages/pipeline/src/http.ts
@@ -1,7 +1,13 @@
-import { Effect, Schedule } from "effect";
+import { Duration, Effect, Schedule } from "effect";
 
 import type { PipelineConfigValues } from "./config";
-import { HttpError, NetworkError, TimeoutError } from "./error";
+import {
+  HttpError,
+  NetworkError,
+  type PipelineError,
+  RateLimitError,
+  TimeoutError,
+} from "./error";
 import { formatUnknownError } from "./util";
 
 export interface FetchResponseRequest<ETimeout, ENetwork> {
@@ -31,8 +37,30 @@ export interface FetchTextRequest {
   readonly bodyReadMessage: (error: unknown) => string;
 }
 
+export interface ReadResponseJsonRequest {
+  readonly url: string;
+  readonly method: string;
+  readonly jsonParseMessage: (error: unknown) => string;
+}
+
+export interface FetchJsonRequest {
+  readonly url: string;
+  readonly timeoutMs: number;
+  readonly method?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly redirect?: "follow" | "error" | "manual";
+  readonly body?: string;
+  readonly timeoutMessage: string;
+  readonly networkMessage: (error: unknown) => string;
+  readonly httpMessage: (statusCode: number, statusText: string) => string;
+  readonly rateLimitMessage: string;
+  readonly jsonParseMessage: (error: unknown) => string;
+}
+
 export const fetchResponse = <ETimeout, ENetwork>(
-  request: FetchResponseRequest<ETimeout, ENetwork>,
+  request: FetchResponseRequest<ETimeout, ENetwork> & {
+    readonly body?: string;
+  },
 ): Effect.Effect<Response, ETimeout | ENetwork> =>
   Effect.gen(function* () {
     const controller = new AbortController();
@@ -42,7 +70,8 @@ export const fetchResponse = <ETimeout, ENetwork>(
 
     const requestInit = {
       method: request.method ?? "GET",
-      headers: request.headers,
+      ...(request.headers ? { headers: request.headers } : {}),
+      ...(request.body ? { body: request.body } : {}),
       signal: controller.signal,
       ...(request.redirect ? { redirect: request.redirect } : {}),
     };
@@ -72,6 +101,21 @@ export const readResponseText = <EBodyRead>(
   Effect.tryPromise({
     try: () => response.text(),
     catch: (error) => request.bodyReadError(request.url, error),
+  });
+
+export const readResponseJson = (
+  response: Response,
+  request: ReadResponseJsonRequest,
+): Effect.Effect<unknown, HttpError> =>
+  Effect.tryPromise({
+    try: () => response.json(),
+    catch: (error) =>
+      new HttpError({
+        message: request.jsonParseMessage(error),
+        url: request.url,
+        method: request.method,
+        cause: error,
+      }),
   });
 
 export const fetchText = (
@@ -121,6 +165,100 @@ export const fetchText = (
         }),
     });
   });
+
+export const fetchJson = (
+  request: FetchJsonRequest,
+): Effect.Effect<
+  unknown,
+  HttpError | NetworkError | TimeoutError | RateLimitError
+> =>
+  Effect.gen(function* () {
+    const method = request.method ?? "GET";
+
+    const response = yield* fetchResponse({
+      url: request.url,
+      timeoutMs: request.timeoutMs,
+      timeoutError: (url, timeoutMs) =>
+        new TimeoutError({
+          message: request.timeoutMessage,
+          url,
+          timeoutMs,
+        }),
+      networkError: (url, error) =>
+        new NetworkError({
+          message: request.networkMessage(error),
+          url,
+          cause: error,
+        }),
+      ...(request.headers ? { headers: request.headers } : {}),
+      ...(request.redirect ? { redirect: request.redirect } : {}),
+      ...(request.body ? { body: request.body } : {}),
+      ...(request.method ? { method: request.method } : {}),
+    });
+
+    if (response.status === 429) {
+      const retryAfter = response.headers.get("retry-after");
+      const retryAfterMs = retryAfter
+        ? Number.parseInt(retryAfter, 10) * 1000
+        : undefined;
+
+      return yield* Effect.fail(
+        new RateLimitError({
+          message: request.rateLimitMessage,
+          url: request.url,
+          retryAfterMs,
+        }),
+      );
+    }
+
+    if (!response.ok) {
+      return yield* Effect.fail(
+        new HttpError({
+          message: request.httpMessage(response.status, response.statusText),
+          url: request.url,
+          method,
+          statusCode: response.status,
+        }),
+      );
+    }
+
+    return yield* readResponseJson(response, {
+      url: request.url,
+      method,
+      jsonParseMessage: request.jsonParseMessage,
+    });
+  });
+
+export const retryPipelineRequest = <A, R>(
+  effect: () => Effect.Effect<A, PipelineError, R>,
+  options: Pick<PipelineConfigValues, "maxRetries"> & {
+    readonly retryDelayMs: number;
+  },
+): Effect.Effect<A, PipelineError, R> =>
+  effect().pipe(
+    Effect.retry({
+      schedule: Schedule.exponential(Duration.millis(options.retryDelayMs)),
+      times: options.maxRetries,
+      while: (error: PipelineError) =>
+        error instanceof NetworkError || error instanceof TimeoutError,
+    }),
+    Effect.catchTag("RateLimitError", (error) =>
+      Effect.sleep(
+        Duration.millis(error.retryAfterMs ?? options.retryDelayMs),
+      ).pipe(
+        Effect.andThen(
+          effect().pipe(
+            Effect.retry({
+              schedule: Schedule.exponential(
+                Duration.millis(options.retryDelayMs),
+              ),
+              times: options.maxRetries,
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
 
 export const fetchTextWithRetry = (
   request: FetchTextRequest,

--- a/packages/pipeline/src/http.ts
+++ b/packages/pipeline/src/http.ts
@@ -1,0 +1,98 @@
+import { Effect, Schedule } from "effect";
+
+import type { PipelineConfigValues } from "./config";
+import { HttpError, NetworkError, TimeoutError } from "./error";
+import { formatUnknownError } from "./util";
+
+export interface FetchTextRequest {
+  readonly url: string;
+  readonly timeoutMs: number;
+  readonly method?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly redirect?: "follow" | "error" | "manual";
+  readonly timeoutMessage: string;
+  readonly networkMessage: (error: unknown) => string;
+  readonly httpMessage: (statusCode: number) => string;
+  readonly bodyReadMessage: (error: unknown) => string;
+}
+
+export const fetchText = Effect.fn("pipeline.fetchText")(function* (
+  request: FetchTextRequest,
+) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, request.timeoutMs);
+
+  const requestInit = {
+    method: request.method ?? "GET",
+    headers: request.headers,
+    signal: controller.signal,
+    ...(request.redirect ? { redirect: request.redirect } : {}),
+  };
+
+  const response = yield* Effect.tryPromise({
+    try: () => fetch(request.url, requestInit),
+    catch: (error) => {
+      if (error instanceof Error && error.name === "AbortError") {
+        return new TimeoutError({
+          message: request.timeoutMessage,
+          url: request.url,
+          timeoutMs: request.timeoutMs,
+        });
+      }
+
+      return new NetworkError({
+        message: request.networkMessage(error),
+        url: request.url,
+        cause: error,
+      });
+    },
+  }).pipe(
+    Effect.ensuring(
+      Effect.sync(() => {
+        clearTimeout(timeoutId);
+      }),
+    ),
+  );
+
+  if (response.status >= 400) {
+    return yield* Effect.fail(
+      new HttpError({
+        message: request.httpMessage(response.status),
+        url: request.url,
+        method: request.method ?? "GET",
+        statusCode: response.status,
+      }),
+    );
+  }
+
+  return yield* Effect.tryPromise({
+    try: () => response.text(),
+    catch: (error) =>
+      new NetworkError({
+        message: request.bodyReadMessage(error),
+        url: request.url,
+        cause: error,
+      }),
+  });
+});
+
+export const fetchTextWithRetry = (
+  request: FetchTextRequest,
+  pipelineConfig: Pick<PipelineConfigValues, "retryDelay" | "maxRetries">,
+) =>
+  fetchText(request).pipe(
+    Effect.retry({
+      schedule: Schedule.exponential(pipelineConfig.retryDelay),
+      times: pipelineConfig.maxRetries,
+      while: (error: HttpError | NetworkError | TimeoutError) =>
+        error instanceof NetworkError || error instanceof TimeoutError,
+    }),
+  );
+
+export const defaultNetworkMessage = (label: string, error: unknown) =>
+  `${label} network error: ${formatUnknownError(error)}`;
+
+export const defaultBodyReadMessage = (label: string, error: unknown) =>
+  `Failed to read ${label} response body: ${formatUnknownError(error)}`;

--- a/packages/pipeline/src/mll/mll.client.ts
+++ b/packages/pipeline/src/mll/mll.client.ts
@@ -1,8 +1,19 @@
 import * as cheerio from "cheerio";
-import { Effect, Schedule, Schema, ServiceMap, Layer } from "effect";
+import { Effect, Layer, Schedule, Schema, ServiceMap } from "effect";
 
 import { MLLConfig, PipelineConfig } from "../config";
-import { HttpError, NetworkError, ParseError, TimeoutError } from "../error";
+import {
+  type HttpError,
+  NetworkError,
+  ParseError,
+  TimeoutError,
+} from "../error";
+import {
+  defaultBodyReadMessage,
+  defaultNetworkMessage,
+  fetchTextWithRetry,
+} from "../http";
+import { safeParseJson } from "../util";
 
 import {
   MLLGame,
@@ -143,96 +154,29 @@ export class MLLClient extends ServiceMap.Service<MLLClient>()("MLLClient", {
     // Re-export cheerio for HTML parsing in methods
     const $ = cheerio;
 
-    /**
-     * Fetches a page from StatsCrew with browser-like headers.
-     * Returns the HTML content as a string.
-     */
-    const fetchStatscrewPage = (
-      path: string,
-    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
-      Effect.gen(function* () {
-        const url = `${mllConfig.statscrewBaseUrl}${path.startsWith("/") ? path : `/${path}`}`;
-        const timeoutMs = pipelineConfig.defaultTimeoutMs;
-
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => {
-          controller.abort();
-        }, timeoutMs);
-
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            fetch(url, {
-              method: "GET",
-              headers: {
-                ...mllConfig.headers,
-                Accept:
-                  "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.9",
-              },
-              signal: controller.signal,
-            }),
-          catch: (error) => {
-            clearTimeout(timeoutId);
-            if (error instanceof Error && error.name === "AbortError") {
-              return new TimeoutError({
-                message: `Request timed out after ${timeoutMs}ms`,
-                url,
-                timeoutMs,
-              });
-            }
-            return new NetworkError({
-              message: `Network error: ${String(error)}`,
-              url,
-              cause: error,
-            });
-          },
-        }).pipe(
-          Effect.tap(() =>
-            Effect.sync(() => {
-              clearTimeout(timeoutId);
-            }),
-          ),
-        );
-
-        if (response.status >= 400) {
-          return yield* Effect.fail(
-            new HttpError({
-              message: `HTTP ${response.status} error`,
-              url,
-              method: "GET",
-              statusCode: response.status,
-            }),
-          );
-        }
-
-        const html = yield* Effect.tryPromise({
-          try: () => response.text(),
-          catch: (error) =>
-            new NetworkError({
-              message: `Failed to read response body: ${String(error)}`,
-              url,
-              cause: error,
-            }),
-        });
-
-        return html;
-      });
-
-    /**
-     * Fetches a StatsCrew page with exponential backoff retry.
-     * Retries on network and timeout errors only.
-     */
     const fetchStatscrewPageWithRetry = (
       path: string,
-    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
-      fetchStatscrewPage(path).pipe(
-        Effect.retry({
-          schedule: Schedule.exponential(pipelineConfig.retryDelay),
-          times: pipelineConfig.maxRetries,
-          while: (error: HttpError | NetworkError | TimeoutError) =>
-            error instanceof NetworkError || error instanceof TimeoutError,
-        }),
+    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> => {
+      const url = `${mllConfig.statscrewBaseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+
+      return fetchTextWithRetry(
+        {
+          url,
+          timeoutMs: pipelineConfig.defaultTimeoutMs,
+          headers: {
+            ...mllConfig.headers,
+            Accept:
+              "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+          },
+          timeoutMessage: `Request timed out after ${pipelineConfig.defaultTimeoutMs}ms`,
+          networkMessage: (error) => defaultNetworkMessage("Request", error),
+          httpMessage: (statusCode) => `HTTP ${statusCode} error`,
+          bodyReadMessage: (error) => defaultBodyReadMessage("response", error),
+        },
+        pipelineConfig,
       );
+    };
 
     /**
      * Queries the Wayback Machine CDX API for archived URLs.
@@ -255,65 +199,27 @@ export class MLLClient extends ServiceMap.Service<MLLClient>()("MLLClient", {
           ...params,
         });
         const cdxUrl = `${mllConfig.waybackCdxUrl}?${queryParams.toString()}`;
-        const timeoutMs = pipelineConfig.defaultTimeoutMs;
 
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => {
-          controller.abort();
-        }, timeoutMs);
-
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            fetch(cdxUrl, {
-              method: "GET",
-              headers: {
-                ...mllConfig.headers,
-                Accept: "application/json",
-              },
-              signal: controller.signal,
-            }),
-          catch: (error) => {
-            clearTimeout(timeoutId);
-            if (error instanceof Error && error.name === "AbortError") {
-              return new TimeoutError({
-                message: `CDX request timed out after ${timeoutMs}ms`,
-                url: cdxUrl,
-                timeoutMs,
-              });
-            }
-            return new NetworkError({
-              message: `CDX network error: ${String(error)}`,
-              url: cdxUrl,
-              cause: error,
-            });
+        const body = yield* fetchTextWithRetry(
+          {
+            url: cdxUrl,
+            timeoutMs: pipelineConfig.defaultTimeoutMs,
+            headers: {
+              ...mllConfig.headers,
+              Accept: "application/json",
+            },
+            timeoutMessage: `CDX request timed out after ${pipelineConfig.defaultTimeoutMs}ms`,
+            networkMessage: (error) => defaultNetworkMessage("CDX", error),
+            httpMessage: (statusCode) => `CDX API HTTP ${statusCode} error`,
+            bodyReadMessage: (error) => defaultBodyReadMessage("CDX", error),
           },
-        }).pipe(
-          Effect.tap(() =>
-            Effect.sync(() => {
-              clearTimeout(timeoutId);
-            }),
-          ),
+          pipelineConfig,
         );
 
-        if (response.status >= 400) {
-          return yield* Effect.fail(
-            new HttpError({
-              message: `CDX API HTTP ${response.status} error`,
-              url: cdxUrl,
-              method: "GET",
-              statusCode: response.status,
-            }),
-          );
-        }
-
-        const json = yield* Effect.tryPromise({
-          try: () => response.json(),
-          catch: (error) =>
-            new ParseError({
-              message: `Failed to parse CDX JSON response: ${String(error)}`,
-              cause: error,
-            }),
-        });
+        const json = yield* safeParseJson<unknown>(
+          body,
+          "Failed to parse CDX JSON response",
+        );
 
         // CDX returns array where first row is headers, rest are data rows
         // Format: [["urlkey", "timestamp", "original", "mimetype", "statuscode", "digest", "length"], [...data...], ...]
@@ -366,102 +272,31 @@ export class MLLClient extends ServiceMap.Service<MLLClient>()("MLLClient", {
         }),
       );
 
-    /**
-     * Fetches an archived page from the Wayback Machine.
-     * Returns the HTML content as a string.
-     *
-     * @param timestamp - Wayback timestamp (e.g., "20060501120000")
-     * @param url - Original URL to fetch (e.g., "http://majorleaguelacrosse.com/schedule/")
-     */
-    const fetchWaybackPage = (
-      timestamp: string,
-      url: string,
-    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
-      Effect.gen(function* () {
-        const waybackUrl = `${mllConfig.waybackWebUrl}/${timestamp}/${url}`;
-        const timeoutMs = pipelineConfig.defaultTimeoutMs;
-
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => {
-          controller.abort();
-        }, timeoutMs);
-
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            fetch(waybackUrl, {
-              method: "GET",
-              headers: {
-                ...mllConfig.headers,
-                Accept:
-                  "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.9",
-              },
-              signal: controller.signal,
-              redirect: "follow",
-            }),
-          catch: (error) => {
-            clearTimeout(timeoutId);
-            if (error instanceof Error && error.name === "AbortError") {
-              return new TimeoutError({
-                message: `Wayback request timed out after ${timeoutMs}ms`,
-                url: waybackUrl,
-                timeoutMs,
-              });
-            }
-            return new NetworkError({
-              message: `Wayback network error: ${String(error)}`,
-              url: waybackUrl,
-              cause: error,
-            });
-          },
-        }).pipe(
-          Effect.tap(() =>
-            Effect.sync(() => {
-              clearTimeout(timeoutId);
-            }),
-          ),
-        );
-
-        if (response.status >= 400) {
-          return yield* Effect.fail(
-            new HttpError({
-              message: `Wayback HTTP ${response.status} error`,
-              url: waybackUrl,
-              method: "GET",
-              statusCode: response.status,
-            }),
-          );
-        }
-
-        const html = yield* Effect.tryPromise({
-          try: () => response.text(),
-          catch: (error) =>
-            new NetworkError({
-              message: `Failed to read Wayback response body: ${String(error)}`,
-              url: waybackUrl,
-              cause: error,
-            }),
-        });
-
-        return html;
-      });
-
-    /**
-     * Fetches a Wayback page with exponential backoff retry.
-     * Retries on network and timeout errors only.
-     */
     const fetchWaybackPageWithRetry = (
       timestamp: string,
       url: string,
-    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
-      fetchWaybackPage(timestamp, url).pipe(
-        Effect.retry({
-          schedule: Schedule.exponential(pipelineConfig.retryDelay),
-          times: pipelineConfig.maxRetries,
-          while: (error: HttpError | NetworkError | TimeoutError) =>
-            error instanceof NetworkError || error instanceof TimeoutError,
-        }),
+    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> => {
+      const waybackUrl = `${mllConfig.waybackWebUrl}/${timestamp}/${url}`;
+
+      return fetchTextWithRetry(
+        {
+          url: waybackUrl,
+          timeoutMs: pipelineConfig.defaultTimeoutMs,
+          headers: {
+            ...mllConfig.headers,
+            Accept:
+              "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+          },
+          redirect: "follow",
+          timeoutMessage: `Wayback request timed out after ${pipelineConfig.defaultTimeoutMs}ms`,
+          networkMessage: (error) => defaultNetworkMessage("Wayback", error),
+          httpMessage: (statusCode) => `Wayback HTTP ${statusCode} error`,
+          bodyReadMessage: (error) => defaultBodyReadMessage("Wayback", error),
+        },
+        pipelineConfig,
       );
+    };
 
     /**
      * Fetches all teams for a given MLL season year.

--- a/packages/pipeline/src/msl/msl.client.ts
+++ b/packages/pipeline/src/msl/msl.client.ts
@@ -1,13 +1,18 @@
 import * as cheerio from "cheerio";
-import { Effect, Schedule, Schema, ServiceMap, Layer } from "effect";
+import { Effect, Layer, Schema, ServiceMap } from "effect";
 
 import { MSLConfig, PipelineConfig } from "../config";
 import {
-  HttpError,
-  NetworkError,
+  type HttpError,
+  type NetworkError,
   type ParseError,
-  TimeoutError,
+  type TimeoutError,
 } from "../error";
+import {
+  defaultBodyReadMessage,
+  defaultNetworkMessage,
+  fetchTextWithRetry,
+} from "../http";
 import { mapParseError, safeParseJson, safeStringOrNull } from "../util";
 
 import {
@@ -34,191 +39,55 @@ export class MSLClient extends ServiceMap.Service<MSLClient>()("MSLClient", {
     // Re-export cheerio for potential future HTML parsing needs
     const $ = cheerio;
 
-    /**
-     * Fetches a page from Gamesheet with browser-like headers.
-     * Returns the HTML content as a string.
-     *
-     * @param path - Path relative to gamesheetBaseUrl (e.g., "/seasons/1234/schedule")
-     */
-    const fetchGamesheetPage = (
-      path: string,
-    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
-      Effect.gen(function* () {
-        const url = `${mslConfig.gamesheetBaseUrl}${path.startsWith("/") ? path : `/${path}`}`;
-        const timeoutMs = pipelineConfig.defaultTimeoutMs;
-
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => {
-          controller.abort();
-        }, timeoutMs);
-
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            fetch(url, {
-              method: "GET",
-              headers: {
-                ...mslConfig.headers,
-                Accept:
-                  "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.9",
-              },
-              signal: controller.signal,
-            }),
-          catch: (error) => {
-            clearTimeout(timeoutId);
-            if (error instanceof Error && error.name === "AbortError") {
-              return new TimeoutError({
-                message: `Gamesheet request timed out after ${timeoutMs}ms`,
-                url,
-                timeoutMs,
-              });
-            }
-            return new NetworkError({
-              message: `Gamesheet network error: ${String(error)}`,
-              url,
-              cause: error,
-            });
-          },
-        }).pipe(
-          Effect.tap(() =>
-            Effect.sync(() => {
-              clearTimeout(timeoutId);
-            }),
-          ),
-        );
-
-        if (response.status >= 400) {
-          return yield* Effect.fail(
-            new HttpError({
-              message: `Gamesheet HTTP ${response.status} error`,
-              url,
-              method: "GET",
-              statusCode: response.status,
-            }),
-          );
-        }
-
-        const html = yield* Effect.tryPromise({
-          try: () => response.text(),
-          catch: (error) =>
-            new NetworkError({
-              message: `Failed to read Gamesheet response body: ${String(error)}`,
-              url,
-              cause: error,
-            }),
-        });
-
-        return html;
-      });
-
-    /**
-     * Fetches a Gamesheet page with exponential backoff retry.
-     * Retries on network and timeout errors only.
-     */
     const fetchGamesheetPageWithRetry = (
       path: string,
-    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
-      fetchGamesheetPage(path).pipe(
-        Effect.retry({
-          schedule: Schedule.exponential(pipelineConfig.retryDelay),
-          times: pipelineConfig.maxRetries,
-          while: (error: HttpError | NetworkError | TimeoutError) =>
-            error instanceof NetworkError || error instanceof TimeoutError,
-        }),
-      );
+    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> => {
+      const url = `${mslConfig.gamesheetBaseUrl}${path.startsWith("/") ? path : `/${path}`}`;
 
-    /**
-     * Fetches a page from the main MSL website with browser-like headers.
-     * Returns the HTML content as a string.
-     *
-     * @param path - Path relative to mainSiteBaseUrl (e.g., "/schedule")
-     */
-    const fetchMainSitePage = (
-      path: string,
-    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
-      Effect.gen(function* () {
-        const url = `${mslConfig.mainSiteBaseUrl}${path.startsWith("/") ? path : `/${path}`}`;
-        const timeoutMs = pipelineConfig.defaultTimeoutMs;
-
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => {
-          controller.abort();
-        }, timeoutMs);
-
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            fetch(url, {
-              method: "GET",
-              headers: {
-                ...mslConfig.headers,
-                Accept:
-                  "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.9",
-              },
-              signal: controller.signal,
-            }),
-          catch: (error) => {
-            clearTimeout(timeoutId);
-            if (error instanceof Error && error.name === "AbortError") {
-              return new TimeoutError({
-                message: `Main site request timed out after ${timeoutMs}ms`,
-                url,
-                timeoutMs,
-              });
-            }
-            return new NetworkError({
-              message: `Main site network error: ${String(error)}`,
-              url,
-              cause: error,
-            });
+      return fetchTextWithRetry(
+        {
+          url,
+          timeoutMs: pipelineConfig.defaultTimeoutMs,
+          headers: {
+            ...mslConfig.headers,
+            Accept:
+              "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
           },
-        }).pipe(
-          Effect.tap(() =>
-            Effect.sync(() => {
-              clearTimeout(timeoutId);
-            }),
-          ),
-        );
+          timeoutMessage: `Gamesheet request timed out after ${pipelineConfig.defaultTimeoutMs}ms`,
+          networkMessage: (error) => defaultNetworkMessage("Gamesheet", error),
+          httpMessage: (statusCode) => `Gamesheet HTTP ${statusCode} error`,
+          bodyReadMessage: (error) =>
+            defaultBodyReadMessage("Gamesheet", error),
+        },
+        pipelineConfig,
+      );
+    };
 
-        if (response.status >= 400) {
-          return yield* Effect.fail(
-            new HttpError({
-              message: `Main site HTTP ${response.status} error`,
-              url,
-              method: "GET",
-              statusCode: response.status,
-            }),
-          );
-        }
-
-        const html = yield* Effect.tryPromise({
-          try: () => response.text(),
-          catch: (error) =>
-            new NetworkError({
-              message: `Failed to read main site response body: ${String(error)}`,
-              url,
-              cause: error,
-            }),
-        });
-
-        return html;
-      });
-
-    /**
-     * Fetches a main site page with exponential backoff retry.
-     * Retries on network and timeout errors only.
-     */
     const fetchMainSitePageWithRetry = (
       path: string,
-    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
-      fetchMainSitePage(path).pipe(
-        Effect.retry({
-          schedule: Schedule.exponential(pipelineConfig.retryDelay),
-          times: pipelineConfig.maxRetries,
-          while: (error: HttpError | NetworkError | TimeoutError) =>
-            error instanceof NetworkError || error instanceof TimeoutError,
-        }),
+    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> => {
+      const url = `${mslConfig.mainSiteBaseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+
+      return fetchTextWithRetry(
+        {
+          url,
+          timeoutMs: pipelineConfig.defaultTimeoutMs,
+          headers: {
+            ...mslConfig.headers,
+            Accept:
+              "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+          },
+          timeoutMessage: `Main site request timed out after ${pipelineConfig.defaultTimeoutMs}ms`,
+          networkMessage: (error) => defaultNetworkMessage("Main site", error),
+          httpMessage: (statusCode) => `Main site HTTP ${statusCode} error`,
+          bodyReadMessage: (error) =>
+            defaultBodyReadMessage("main site", error),
+        },
+        pipelineConfig,
       );
+    };
 
     /**
      * Fetches all teams for a given MSL season.

--- a/packages/pipeline/src/scraper/scraper.client.ts
+++ b/packages/pipeline/src/scraper/scraper.client.ts
@@ -1,6 +1,7 @@
-import { Effect, Schedule, ServiceMap, Layer } from "effect";
+import { Effect, Layer, Schedule, ServiceMap } from "effect";
 
 import { PipelineConfig } from "../config";
+import { fetchResponse, readResponseText } from "../http";
 
 import {
   ScraperHttpError,
@@ -29,43 +30,28 @@ export class ScraperClient extends ServiceMap.Service<ScraperClient>()(
           const startTime = Date.now();
           const timeoutMs = request.timeoutMs ?? config.defaultTimeoutMs;
 
-          const controller = new AbortController();
-          const timeoutId = setTimeout(() => {
-            controller.abort();
-          }, timeoutMs);
-
-          const response = yield* Effect.tryPromise({
-            try: () =>
-              fetch(request.url, {
-                method: "GET",
-                headers: {
-                  "User-Agent": config.userAgent,
-                  ...request.headers,
-                },
-                signal: controller.signal,
-                redirect: request.followRedirects ? "follow" : "manual",
-              }),
-            catch: (error) => {
-              if (error instanceof Error && error.name === "AbortError") {
-                return new ScraperTimeoutError({
-                  message: `Request timed out after ${timeoutMs}ms`,
-                  url: request.url,
-                  timeoutMs,
-                });
-              }
-              return new ScraperNetworkError({
-                message: `Network error: ${String(error)}`,
-                url: request.url,
-                cause: error,
-              });
+          const response = yield* fetchResponse({
+            url: request.url,
+            timeoutMs,
+            method: "GET",
+            headers: {
+              "User-Agent": config.userAgent,
+              ...request.headers,
             },
-          }).pipe(
-            Effect.tap(() =>
-              Effect.sync(() => {
-                clearTimeout(timeoutId);
+            redirect: request.followRedirects ? "follow" : "manual",
+            timeoutError: (url, requestTimeoutMs) =>
+              new ScraperTimeoutError({
+                message: `Request timed out after ${requestTimeoutMs}ms`,
+                url,
+                timeoutMs: requestTimeoutMs,
               }),
-            ),
-          );
+            networkError: (url, error) =>
+              new ScraperNetworkError({
+                message: `Network error: ${String(error)}`,
+                url,
+                cause: error,
+              }),
+          });
 
           const statusCode = response.status;
 
@@ -94,12 +80,12 @@ export class ScraperClient extends ServiceMap.Service<ScraperClient>()(
             );
           }
 
-          const body = yield* Effect.tryPromise({
-            try: () => response.text(),
-            catch: (error) =>
+          const body = yield* readResponseText(response, {
+            url: request.url,
+            bodyReadError: (url, error) =>
               new ScraperNetworkError({
                 message: `Failed to read response body: ${String(error)}`,
-                url: request.url,
+                url,
                 cause: error,
               }),
           });

--- a/packages/pipeline/src/wla/wla.client.ts
+++ b/packages/pipeline/src/wla/wla.client.ts
@@ -1,9 +1,19 @@
 import { isRecord } from "@laxdb/core/type-guards";
 import * as cheerio from "cheerio";
-import { Effect, Layer, Option, Schedule, Schema, ServiceMap } from "effect";
+import { Effect, Layer, Option, Schema, ServiceMap } from "effect";
 
 import { PipelineConfig, WLAConfig } from "../config";
-import { HttpError, NetworkError, ParseError, TimeoutError } from "../error";
+import {
+  type HttpError,
+  type NetworkError,
+  ParseError,
+  type TimeoutError,
+} from "../error";
+import {
+  defaultBodyReadMessage,
+  defaultNetworkMessage,
+  fetchTextWithRetry,
+} from "../http";
 import {
   mapParseError,
   safeParseJson,
@@ -136,97 +146,28 @@ export class WLAClient extends ServiceMap.Service<WLAClient>()("WLAClient", {
     // Re-export cheerio for potential future HTML parsing needs
     const $ = cheerio;
 
-    /**
-     * Fetches a page from the WLA website with browser-like headers.
-     * Returns the HTML content as a string.
-     *
-     * @param url - Full URL to fetch
-     */
-    const fetchPage = (
-      url: string,
-    ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
-      Effect.gen(function* () {
-        const timeoutMs = pipelineConfig.defaultTimeoutMs;
-
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => {
-          controller.abort();
-        }, timeoutMs);
-
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            fetch(url, {
-              method: "GET",
-              headers: {
-                ...wlaConfig.headers,
-                Accept:
-                  "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.9",
-              },
-              signal: controller.signal,
-            }),
-          catch: (error) => {
-            clearTimeout(timeoutId);
-            if (error instanceof Error && error.name === "AbortError") {
-              return new TimeoutError({
-                message: `WLA request timed out after ${timeoutMs}ms`,
-                url,
-                timeoutMs,
-              });
-            }
-            return new NetworkError({
-              message: `WLA network error: ${String(error)}`,
-              url,
-              cause: error,
-            });
-          },
-        }).pipe(
-          Effect.tap(() =>
-            Effect.sync(() => {
-              clearTimeout(timeoutId);
-            }),
-          ),
-        );
-
-        if (response.status >= 400) {
-          return yield* Effect.fail(
-            new HttpError({
-              message: `WLA HTTP ${response.status} error`,
-              url,
-              method: "GET",
-              statusCode: response.status,
-            }),
-          );
-        }
-
-        const html = yield* Effect.tryPromise({
-          try: () => response.text(),
-          catch: (error) =>
-            new NetworkError({
-              message: `Failed to read WLA response body: ${String(error)}`,
-              url,
-              cause: error,
-            }),
-        });
-
-        return html;
-      });
-
-    /**
-     * Fetches a WLA page with exponential backoff retry.
-     * Retries on network and timeout errors only.
-     */
     const fetchPageWithRetry = (
       url: string,
     ): Effect.Effect<string, HttpError | NetworkError | TimeoutError> =>
-      fetchPage(url).pipe(
-        Effect.retry({
-          schedule: Schedule.exponential(pipelineConfig.retryDelay),
-          times: pipelineConfig.maxRetries,
-          while: (error: HttpError | NetworkError | TimeoutError) =>
-            error instanceof NetworkError || error instanceof TimeoutError,
-        }),
+      fetchTextWithRetry(
+        {
+          url,
+          timeoutMs: pipelineConfig.defaultTimeoutMs,
+          headers: {
+            ...wlaConfig.headers,
+            Accept:
+              "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+          },
+          timeoutMessage: `WLA request timed out after ${pipelineConfig.defaultTimeoutMs}ms`,
+          networkMessage: (error) => defaultNetworkMessage("WLA", error),
+          httpMessage: (statusCode) => `WLA HTTP ${statusCode} error`,
+          bodyReadMessage: (error) => defaultBodyReadMessage("WLA", error),
+        },
+        pipelineConfig,
       );
+
+    const fetchPage = fetchPageWithRetry;
 
     /**
      * Maps a calendar year to WLA's Pointstreak season ID.


### PR DESCRIPTION
## Summary
Follow-up cleanup after #164 focused on reducing duplicated fetch/timeout/retry boilerplate in pipeline clients.

## Changes
- add `packages/pipeline/src/http.ts` with shared text-fetch helpers
- reuse the shared helper in WLA, MSL, and MLL clients
- keep behavior intact while shrinking per-client request code

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test`
